### PR TITLE
Fix bug in HTTP FSM

### DIFF
--- a/src/proto/http.rs
+++ b/src/proto/http.rs
@@ -232,6 +232,11 @@ pub fn repl<'a>(
         debug!("pstate: {}", pstate.state);
         return None;
     }
+    /* if not in CONTENT state, not responding yet (it means the client
+     * has not finished sending headers yet) */
+    if pstate.state != HTTP_STATE_CONTENT {
+        return None;
+    }
     let content = "\
 <html>
 <head><title>401 Authorization Required</title></head>


### PR DESCRIPTION
The `HTTP` finite state machine as implemented in [src/proto/http.rs](src/proto/http.rs) return a reply (401) with no prior consideration about the current state of parsing.

For instance, if the client only sends a part of `HTTP` headers in the first `TCP` packet, it will still get an `HTTP` answer.

This PR adds tests to detect the bug and fixes it.