### PR TITLE
Fix FIN,ACK behaviour

### DIFF
--- a/src/layer_4/tcp.rs
+++ b/src/layer_4/tcp.rs
@@ -119,6 +119,56 @@ mod tests {
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
     #[test]
+    fn test_tcp_fin_ack() {
+        let masscanned = Masscanned {
+            mac: MacAddr(0, 0, 0, 0, 0, 0),
+            ip_addresses: None,
+            synack_key: [0x06a0a1d63f305e9b, 0xd4d4bcbb7304875f],
+            iface: None,
+        };
+        /* reference */
+        let ip_src = IpAddr::V4(Ipv4Addr::new(27, 198, 143, 1));
+        let ip_dst = IpAddr::V4(Ipv4Addr::new(90, 64, 122, 203));
+        let tcp_sport = 65500;
+        let tcp_dport = 80;
+        let seq = 1234567;
+        let ack = 7654321;
+        let mut client_info = ClientInfo {
+            mac: ClientInfoSrcDst {
+                src: None,
+                dst: None,
+            },
+            ip: ClientInfoSrcDst {
+                src: Some(ip_src),
+                dst: Some(ip_dst),
+            },
+            transport: None,
+            port: ClientInfoSrcDst {
+                src: Some(tcp_sport),
+                dst: Some(tcp_dport),
+            },
+            cookie: None,
+        };
+        let mut tcp_req =
+            MutableTcpPacket::owned(vec![0; MutableTcpPacket::minimum_packet_size()]).unwrap();
+        tcp_req.set_source(tcp_sport);
+        tcp_req.set_destination(tcp_dport);
+        tcp_req.set_sequence(seq);
+        tcp_req.set_acknowledgement(ack);
+        tcp_req.set_flags(TcpFlags::FIN | TcpFlags::ACK);
+        let some_tcp_repl = repl(&tcp_req.to_immutable(), &masscanned, &mut client_info);
+        if some_tcp_repl == None {
+            panic!("expected a reply, got none");
+        }
+        let tcp_repl = some_tcp_repl.unwrap();
+        /* check reply flags */
+        assert!(tcp_repl.get_flags() == (TcpFlags::FIN | TcpFlags::ACK));
+        /* check reply seq and ack */
+        assert!(tcp_repl.get_sequence() == ack);
+        assert!(tcp_repl.get_acknowledgement() == seq);
+    }
+
+    #[test]
     fn test_synack_cookie_ipv4() {
         let masscanned = Masscanned {
             mac: MacAddr(0, 0, 0, 0, 0, 0),


### PR DESCRIPTION
Masscanned is currently not responding to `FIN,ACK` packets over `TCP`.
This means that clients can never consider a session as terminated. This usually leads to retransmissions that seem unnecessary.

This PR is a quick fix: answers to any `FIN,ACK` packet with a `FIN,ACK` packet.

Maybe we would prefer to answer ton `FIN,ACK` packets only when a session has been previously established. This is open to discussion.

**Pros:** behaviour would be more realistic.
**Cons:** it requires to perform additional checks that are not currently easy to perform. Indeed, the session info is in the TCB which is managed at upper layer (`proto`).

My opinion: for now, I think this heuristic is good enough (but later it might be good to think about moving the TCB table into `tcp.rs`, I think it would make more sense).