### PR TITLE
Bug in Smack with wildcards

### DIFF
--- a/src/smack/smack.rs
+++ b/src/smack/smack.rs
@@ -685,6 +685,34 @@ mod tests {
     }
 
     #[test]
+    fn test_wildcard_collision() {
+        let mut smack = Smack::new("test".to_string(), SMACK_CASE_INSENSITIVE);
+        smack.add_pattern(
+            b"****abcd",
+            0,
+            SmackFlags::ANCHOR_BEGIN | SmackFlags::WILDCARDS,
+        );
+        smack.add_pattern(
+            b"******abcd",
+            1,
+            SmackFlags::ANCHOR_BEGIN | SmackFlags::WILDCARDS,
+        );
+        smack.compile();
+        let mut state = BASE_STATE;
+        let mut offset = 0;
+        let id = smack.search_next(&mut state, &b"xxxxabcd".to_vec(), &mut offset);
+        assert!(id == 0);
+        let mut state = BASE_STATE;
+        let mut offset = 0;
+        let mut id = smack.search_next(&mut state, &b"xxxxxxabcd".to_vec(), &mut offset);
+        assert!(id == 1);
+        let mut state = BASE_STATE;
+        let mut offset = 0;
+        let mut id = smack.search_next(&mut state, &b"xxxxaxabcd".to_vec(), &mut offset);
+        assert!(id == 0);
+    }
+
+    #[test]
     fn test_multiple_matches() {
         let mut smack = Smack::new("test".to_string(), SMACK_CASE_INSENSITIVE);
         smack.add_pattern(b"aabb", 0, SmackFlags::ANCHOR_BEGIN);


### PR DESCRIPTION
When two patterns are added to the smack, with wildcards, and such as wildcards of one pattern overlaps the other one, the smack fails to match in some situations.

The genuine example that has been added as a test case (failing for now) is the following:

```[rust]
    fn test_wildcard_collision() {
        let mut smack = Smack::new("test".to_string(), SMACK_CASE_INSENSITIVE);
        smack.add_pattern(
            b"****abcd",
            0,
            SmackFlags::ANCHOR_BEGIN | SmackFlags::WILDCARDS,
        );
        smack.add_pattern(
            b"******abcd",
            1,
            SmackFlags::ANCHOR_BEGIN | SmackFlags::WILDCARDS,
        );
        smack.compile();
        let mut state = BASE_STATE;
        let mut offset = 0;
        let id = smack.search_next(&mut state, &b"xxxxabcd".to_vec(), &mut offset);
        assert!(id == 0);
        let mut state = BASE_STATE;
        let mut offset = 0;
        let mut id = smack.search_next(&mut state, &b"xxxxxxabcd".to_vec(), &mut offset);
        assert!(id == 1);
        let mut state = BASE_STATE;
        let mut offset = 0;
        let mut id = smack.search_next(&mut state, &b"xxxxaxabcd".to_vec(), &mut offset);
        assert!(id == 0);
    }
```

In this example, the last search (`xxxxaxabcd`) fails, while it shouldn't:

* after reading the first four characters, the smack cannot decide between the two patterns,
* after reading the first `a`, it still could be either of the two patterns,
* but when the fifh `x` is read, then it should be decided that it cannot be the second pattern,
* eventually, after reading the whole string, it should be decided that the first pattern matches (while it currently does not).

Note that this don't happen if the first `a` in the string to parse is replaced by a `b` for instance.
