### PR TITLE
Add support for DNS - Class IN Type A

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,8 @@ pnet = "0.29.0"
 rand = "0.8.4"
 siphasher = "0.3"
 stderrlog = "0.5.0"
+strum = "0.24.1"
+strum_macros = "0.24.2"
 
 [[bin]]
 name = "masscanned"

--- a/src/proto/dissector.rs
+++ b/src/proto/dissector.rs
@@ -1,0 +1,92 @@
+// This file is part of masscanned.
+// Copyright 2021 - The IVRE project
+//
+// Masscanned is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Masscanned is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+// License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Masscanned. If not, see <http://www.gnu.org/licenses/>.
+
+use crate::proto::ClientInfo;
+use crate::proto::TCPControlBlock;
+use crate::Masscanned;
+
+////////////
+// Common //
+////////////
+
+/// ### PacketDissector
+/// A util class used to dissect fields.
+#[derive(Debug, Clone)]
+pub struct PacketDissector<T> {
+    pub i: usize,
+    pub state: T,
+}
+
+impl<T> PacketDissector<T> {
+    pub fn new(initial_state: T) -> PacketDissector<T> {
+        return PacketDissector {
+            i: 0,
+            state: initial_state,
+        };
+    }
+    pub fn next_state(&mut self, state: T) {
+        self.state = state;
+        self.i = 0;
+    }
+    pub fn next_state_when_i_reaches(&mut self, state: T, i: usize) {
+        if self.i == i {
+            self.next_state(state);
+        }
+    }
+    fn _read_usize(&mut self, byte: &u8, value: usize, next_state: T, size: usize) -> usize {
+        self.i += 1;
+        self.next_state_when_i_reaches(next_state, size);
+        (value << 8) + *byte as usize
+    }
+    fn _read_ulesize(&mut self, byte: &u8, value: usize, next_state: T, size: usize) -> usize {
+        let ret = value + ((*byte as usize) << (8 * self.i));
+        self.i += 1;
+        self.next_state_when_i_reaches(next_state, size);
+        ret
+    }
+    pub fn read_u16(&mut self, byte: &u8, value: u16, next_state: T) -> u16 {
+        self._read_usize(byte, value as usize, next_state, 2) as u16
+    }
+    pub fn read_ule16(&mut self, byte: &u8, value: u16, next_state: T) -> u16 {
+        self._read_ulesize(byte, value as usize, next_state, 2) as u16
+    }
+    pub fn read_u32(&mut self, byte: &u8, value: u32, next_state: T) -> u32 {
+        self._read_usize(byte, value as usize, next_state, 4) as u32
+    }
+    pub fn read_ule32(&mut self, byte: &u8, value: u32, next_state: T) -> u32 {
+        self._read_ulesize(byte, value as usize, next_state, 4) as u32
+    }
+    pub fn read_ule64(&mut self, byte: &u8, value: u64, next_state: T) -> u64 {
+        self._read_ulesize(byte, value as usize, next_state, 8) as u64
+    }
+}
+
+pub trait MPacket {
+    fn new() -> Self;
+    fn repl(
+        &self,
+        _masscanned: &Masscanned,
+        _client_info: &ClientInfo,
+        _tcb: Option<&mut TCPControlBlock>,
+    ) -> Option<Vec<u8>>;
+    fn parse(&mut self, byte: &u8);
+
+    fn parse_all(&mut self, bytes: &[u8]) {
+        for byte in bytes {
+            self.parse(byte);
+        }
+    }
+}

--- a/src/proto/dns/cst.rs
+++ b/src/proto/dns/cst.rs
@@ -1,0 +1,93 @@
+// This file is part of masscanned.
+// Copyright 2022 - The IVRE project
+//
+// Masscanned is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Masscanned is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+// License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Masscanned. If not, see <http://www.gnu.org/licenses/>.
+
+use strum_macros::EnumIter;
+
+#[derive(PartialEq, Debug, Clone, Copy, EnumIter)]
+pub enum DNSType {
+    NONE,
+    A,
+    TXT, // value: 16 - text strings
+}
+
+impl From<u16> for DNSType {
+    fn from(item: u16) -> Self {
+        match item {
+            1 => DNSType::A,
+            16 => DNSType::TXT,
+            _ => DNSType::NONE,
+        }
+    }
+}
+
+impl From<DNSType> for u16 {
+    fn from(item: DNSType) -> Self {
+        match item {
+            DNSType::A => 1,
+            DNSType::TXT => 16,
+            _ => 0,
+        }
+    }
+}
+
+#[derive(PartialEq, Debug, Clone, Copy, EnumIter)]
+pub enum DNSClass {
+    NONE,
+    IN, // value: 1 - the Internet
+    CH, // value: 3 - the CHAOS class
+}
+
+impl From<u16> for DNSClass {
+    fn from(item: u16) -> Self {
+        match item {
+            1 => DNSClass::IN,
+            3 => DNSClass::CH,
+            _ => DNSClass::NONE,
+        }
+    }
+}
+
+impl From<DNSClass> for u16 {
+    fn from(item: DNSClass) -> Self {
+        match item {
+            DNSClass::IN => 1,
+            DNSClass::CH => 3,
+            _ => 0,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn type_parse() {
+        /* type TXT */
+        assert!(DNSType::from(1) == DNSType::A);
+        assert!(1 as u16 == DNSType::A.into());
+        assert!(DNSType::from(16) == DNSType::TXT);
+        assert!(16 as u16 == DNSType::TXT.into());
+    }
+
+    #[test]
+    fn class_parse() {
+        assert!(DNSClass::from(1) == DNSClass::IN);
+        assert!(1 as u16 == DNSClass::IN.into());
+        assert!(DNSClass::from(3) == DNSClass::CH);
+        assert!(3 as u16 == DNSClass::CH.into());
+    }
+}

--- a/src/proto/dns/header.rs
+++ b/src/proto/dns/header.rs
@@ -1,0 +1,383 @@
+// This file is part of masscanned.
+// Copyright 2022 - The IVRE project
+//
+// Masscanned is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Masscanned is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+// License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Masscanned. If not, see <http://www.gnu.org/licenses/>.
+
+use std::convert::TryFrom;
+
+use crate::proto::dissector::{MPacket, PacketDissector};
+use crate::proto::ClientInfo;
+use crate::proto::TCPControlBlock;
+use crate::Masscanned;
+
+#[derive(PartialEq)]
+pub enum DNSHeaderState {
+    Id,
+    Flags,
+    QDCount,
+    ANCount,
+    NSCount,
+    ARCount,
+    End,
+}
+
+pub struct DNSHeader {
+    pub d: PacketDissector<DNSHeaderState>,
+    pub id: u16,
+    pub flags: u16,
+    pub _qr: bool,
+    pub _opcode: u8,
+    pub _aa: bool,
+    pub _tc: bool,
+    pub _rd: bool,
+    pub _ra: bool,
+    pub _z: u8,
+    pub _rcode: u8,
+    pub qdcount: u16,
+    pub ancount: u16,
+    pub nscount: u16,
+    pub arcount: u16,
+}
+
+impl TryFrom<Vec<u8>> for DNSHeader {
+    type Error = &'static str;
+
+    fn try_from(item: Vec<u8>) -> Result<Self, Self::Error> {
+        let mut hdr = DNSHeader::new();
+        for b in item {
+            hdr.parse(&b);
+        }
+        if hdr.d.state == DNSHeaderState::End {
+            Ok(hdr)
+        } else {
+            Err("packet is incomplete")
+        }
+    }
+}
+
+impl From<&DNSHeader> for Vec<u8> {
+    fn from(item: &DNSHeader) -> Self {
+        let mut v = Vec::new();
+        /* id */
+        v.push((item.id >> 8) as u8);
+        v.push((item.id & 0xFF) as u8);
+
+        /* flags */
+        /* QR | OPCODE | AA | TC | RD */
+        v.push(
+            ((item._qr as u8) << 7)
+                | (item._opcode << 3)
+                | ((item._aa as u8) << 2)
+                | ((item._tc as u8) << 1)
+                | (item._rd as u8),
+        );
+        /* AA | ZZZ | RCODE */
+        v.push(0);
+
+        /* qdcount */
+        v.push((item.qdcount >> 8) as u8);
+        v.push((item.qdcount & 0xFF) as u8);
+
+        /* ancount */
+        v.push((item.ancount >> 8) as u8);
+        v.push((item.ancount & 0xFF) as u8);
+
+        /* nscount */
+        v.push((item.nscount >> 8) as u8);
+        v.push((item.nscount & 0xFF) as u8);
+
+        /* arcount */
+        v.push((item.arcount >> 8) as u8);
+        v.push((item.arcount & 0xFF) as u8);
+
+        v
+    }
+}
+
+impl MPacket for DNSHeader {
+    fn new() -> Self {
+        DNSHeader {
+            d: PacketDissector::new(DNSHeaderState::Id),
+            id: 0,
+            flags: 0,
+            _qr: false,
+            _opcode: 0,
+            _aa: false,
+            _tc: false,
+            _rd: false,
+            _ra: false,
+            _z: 0,
+            _rcode: 0,
+            qdcount: 0,
+            ancount: 0,
+            nscount: 0,
+            arcount: 0,
+        }
+    }
+
+    fn parse(&mut self, byte: &u8) {
+        match self.d.state {
+            DNSHeaderState::Id => {
+                self.id = self.d.read_u16(byte, self.id, DNSHeaderState::Flags);
+            }
+            DNSHeaderState::Flags => {
+                self.flags = self.d.read_u16(byte, self.flags, DNSHeaderState::QDCount);
+            }
+            DNSHeaderState::QDCount => {
+                self.qdcount = self.d.read_u16(byte, self.qdcount, DNSHeaderState::ANCount);
+            }
+            DNSHeaderState::ANCount => {
+                self.ancount = self.d.read_u16(byte, self.ancount, DNSHeaderState::NSCount);
+            }
+            DNSHeaderState::NSCount => {
+                self.nscount = self.d.read_u16(byte, self.nscount, DNSHeaderState::ARCount);
+            }
+            DNSHeaderState::ARCount => {
+                self.arcount = self.d.read_u16(byte, self.arcount, DNSHeaderState::End);
+            }
+            DNSHeaderState::End => {}
+        }
+        /* we need this to be executed at the same call
+         * the state changes to End, hence it is not in the
+         * match structure
+         **/
+        if self.d.state == DNSHeaderState::End {
+            self._qr = (self.flags >> 15) == 1;
+            self._opcode = ((self.flags >> 11) & 0x0F) as u8;
+            self._aa = (self.flags >> 10) & 0x01 == 1;
+            self._tc = (self.flags >> 9) & 0x01 == 1;
+            self._rd = (self.flags >> 8) & 0x01 == 1;
+            self._ra = (self.flags >> 7) & 0x01 == 1;
+            self._z = ((self.flags >> 4) & 0x07) as u8;
+            self._rcode = (self.flags & 0x0F) as u8;
+        }
+    }
+
+    fn repl(
+        &self,
+        _masscanned: &Masscanned,
+        _client_info: &ClientInfo,
+        _tcb: Option<&mut TCPControlBlock>,
+    ) -> Option<Vec<u8>> {
+        let mut r = DNSHeader::new();
+        r.id = self.id;
+        r._qr = true;
+        r._opcode = self._opcode;
+        r._aa = true;
+        r._tc = false;
+        /*  RFC1035
+         *  Recursion Desired - this bit may be set in a query and
+         *      is copied into the response. */
+        r._rd = self._rd;
+        r._ra = false;
+        r.qdcount = self.qdcount;
+        r.ancount = self.qdcount;
+        Some(Vec::<u8>::from(&r))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use pnet::util::MacAddr;
+    use std::str::FromStr;
+
+    use crate::logger::MetaLogger;
+
+    #[test]
+    fn parse_all() {
+        let payload = b"\xb3\x07\x01\x00\x00\x01\x00\x00\x00\x00\x00\x00";
+        let hdr = match DNSHeader::try_from(payload.to_vec()) {
+            Ok(_hdr) => _hdr,
+            Err(e) => panic!("error while parsing DNS header: {}", e),
+        };
+        assert!(hdr.d.state == DNSHeaderState::End);
+        assert!(hdr.id == 0xb307);
+        assert!(hdr.flags == 0x0100);
+        assert!(hdr._qr == false);
+        assert!(hdr._opcode == 0);
+        assert!(hdr._aa == false);
+        assert!(hdr._tc == false);
+        assert!(hdr._rd == true);
+        assert!(hdr._ra == false);
+        assert!(hdr._z == 0);
+        assert!(hdr._rcode == 0);
+        assert!(hdr.qdcount == 1);
+        assert!(hdr.ancount == 0);
+        assert!(hdr.nscount == 0);
+        assert!(hdr.arcount == 0);
+        assert!(Vec::<u8>::from(&hdr) == payload.to_vec());
+        /* KO */
+        let payload = b"\xb3\x07\x01\x00\x00\x01\x00\x00\x00\x00\x00";
+        match DNSHeader::try_from(payload.to_vec()) {
+            Ok(_) => panic!("parsing should have failed"),
+            Err(_) => {}
+        };
+    }
+
+    #[test]
+    fn parse_byte_by_byte() {
+        /* OK */
+        let payload = b"\xb3\x07\x01\x00\x00\x01\x00\x00\x00\x00\x00\x00";
+        let mut hdr = DNSHeader::new();
+        for b in payload {
+            assert!(hdr.d.state != DNSHeaderState::End);
+            hdr.parse(b);
+        }
+        assert!(hdr.d.state == DNSHeaderState::End);
+        assert!(hdr.id == 0xb307);
+        assert!(hdr.flags == 0x0100);
+        assert!(hdr._qr == false);
+        assert!(hdr._opcode == 0);
+        assert!(hdr._aa == false);
+        assert!(hdr._tc == false);
+        assert!(hdr._rd == true);
+        assert!(hdr._ra == false);
+        assert!(hdr._z == 0);
+        assert!(hdr._rcode == 0);
+        assert!(hdr.qdcount == 1);
+        assert!(hdr.ancount == 0);
+        assert!(hdr.nscount == 0);
+        assert!(hdr.arcount == 0);
+        assert!(Vec::<u8>::from(&hdr) == payload.to_vec());
+        /* KO */
+        let payload = b"\xb3\x07\x01\x00\x00\x01\x00\x00\x00\x00\x00";
+        let mut hdr = DNSHeader::new();
+        for b in payload {
+            hdr.parse(b);
+        }
+        assert!(hdr.d.state != DNSHeaderState::End);
+    }
+
+    fn consistency_qd_rr(qd: &DNSHeader, rr: &DNSHeader) {
+        assert!(rr.id == qd.id);
+        assert!(rr._qr == true);
+        assert!(rr._opcode == qd._opcode);
+        assert!(rr._aa == true);
+        assert!(rr._tc == false);
+        assert!(rr._rd == qd._rd);
+        assert!(rr._ra == false);
+        assert!(rr._z == 0);
+        assert!(rr._rcode == 0);
+        /* check flags */
+        assert!(rr.flags >> 15 == rr._qr as u16);
+        assert!((rr.flags >> 11) & 0xF == rr._opcode as u16);
+        assert!((rr.flags >> 10) & 0x1 == rr._aa as u16);
+        assert!((rr.flags >> 9) & 0x1 == rr._tc as u16);
+        assert!((rr.flags >> 8) & 0x1 == rr._rd as u16);
+        assert!((rr.flags >> 7) & 0x1 == rr._ra as u16);
+        assert!((rr.flags >> 4) & 0x7 == rr._z as u16);
+        assert!(rr.flags & 0xF == rr._rcode as u16);
+        assert!(rr.qdcount == qd.qdcount);
+        assert!(rr.ancount == qd.qdcount);
+        assert!(rr.nscount == 0);
+        assert!(rr.arcount == 0);
+    }
+
+    #[test]
+    fn repl_id() {
+        let masscanned = Masscanned {
+            synack_key: [0, 0],
+            mac: MacAddr::from_str("00:00:00:00:00:00").expect("error parsing default MAC address"),
+            iface: None,
+            ip_addresses: None,
+            log: MetaLogger::new(),
+        };
+        let client_info = ClientInfo::new();
+        let mut hdr = DNSHeader::new();
+        hdr._qr = false;
+        for id in [0x1234, 0x4321, 0xffff, 0x0, 0x1337] {
+            hdr.id = id;
+            let hdr_repl = if let Some(r) = hdr.repl(&masscanned, &client_info, None) {
+                DNSHeader::try_from(r).unwrap()
+            } else {
+                panic!("expected DNS header answer, got None");
+            };
+            consistency_qd_rr(&hdr, &hdr_repl);
+        }
+    }
+
+    #[test]
+    fn repl_opcode() {
+        let masscanned = Masscanned {
+            synack_key: [0, 0],
+            mac: MacAddr::from_str("00:00:00:00:00:00").expect("error parsing default MAC address"),
+            iface: None,
+            ip_addresses: None,
+            log: MetaLogger::new(),
+        };
+        let client_info = ClientInfo::new();
+        let mut hdr = DNSHeader::new();
+        hdr._qr = false;
+        /* opcode */
+        for opcode in 0..3 {
+            hdr._opcode = opcode;
+            let hdr_repl = if let Some(r) = hdr.repl(&masscanned, &client_info, None) {
+                DNSHeader::try_from(r).unwrap()
+            } else {
+                panic!("expected DNS header answer, got None");
+            };
+            consistency_qd_rr(&hdr, &hdr_repl);
+        }
+    }
+
+    #[test]
+    fn repl_rd() {
+        let masscanned = Masscanned {
+            synack_key: [0, 0],
+            mac: MacAddr::from_str("00:00:00:00:00:00").expect("error parsing default MAC address"),
+            iface: None,
+            ip_addresses: None,
+            log: MetaLogger::new(),
+        };
+        let client_info = ClientInfo::new();
+        let mut hdr = DNSHeader::new();
+        hdr._qr = false;
+        /* rd */
+        for rd in [false, true] {
+            hdr._rd = rd;
+            let hdr_repl = if let Some(r) = hdr.repl(&masscanned, &client_info, None) {
+                DNSHeader::try_from(r).unwrap()
+            } else {
+                panic!("expected DNS header answer, got None");
+            };
+            consistency_qd_rr(&hdr, &hdr_repl);
+        }
+    }
+
+    #[test]
+    fn repl_ancount() {
+        let masscanned = Masscanned {
+            synack_key: [0, 0],
+            mac: MacAddr::from_str("00:00:00:00:00:00").expect("error parsing default MAC address"),
+            iface: None,
+            ip_addresses: None,
+            log: MetaLogger::new(),
+        };
+        let client_info = ClientInfo::new();
+        let mut hdr = DNSHeader::new();
+        hdr._qr = false;
+        /* rd */
+        for qdcount in 0..16 {
+            hdr.qdcount = qdcount;
+            let hdr_repl = if let Some(r) = hdr.repl(&masscanned, &client_info, None) {
+                DNSHeader::try_from(r).unwrap()
+            } else {
+                panic!("expected DNS header answer, got None");
+            };
+            consistency_qd_rr(&hdr, &hdr_repl);
+        }
+    }
+}

--- a/src/proto/dns/mod.rs
+++ b/src/proto/dns/mod.rs
@@ -1,0 +1,687 @@
+// This file is part of masscanned.
+// Copyright 2022 - The IVRE project
+//
+// Masscanned is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Masscanned is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+// License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Masscanned. If not, see <http://www.gnu.org/licenses/>.
+
+use std::convert::TryFrom;
+
+mod cst;
+
+mod header;
+use header::{DNSHeader, DNSHeaderState};
+
+mod query;
+use query::{DNSQuery, DNSQueryState};
+
+mod rr;
+use rr::{DNSRRState, DNSRR};
+
+use crate::proto::dissector::{MPacket, PacketDissector};
+use crate::proto::ClientInfo;
+use crate::proto::TCPControlBlock;
+use crate::Masscanned;
+
+#[derive(PartialEq, Debug)]
+enum DNSState {
+    Header,
+    Query,
+    Answer,
+    Authority,
+    Additional,
+    End,
+}
+
+pub struct DNSPacket {
+    d: PacketDissector<DNSState>,
+    header: DNSHeader,
+    qd: Vec<DNSQuery>,
+    rr: Vec<DNSRR>,
+    ns: Vec<DNSRR>,
+    ar: Vec<DNSRR>,
+}
+
+impl TryFrom<Vec<u8>> for DNSPacket {
+    type Error = &'static str;
+
+    fn try_from(item: Vec<u8>) -> Result<Self, Self::Error> {
+        let mut dns = DNSPacket::new();
+        for b in item {
+            dns.parse(&b);
+        }
+        if dns.d.state == DNSState::End {
+            Ok(dns)
+        } else {
+            Err("packet is incomplete")
+        }
+    }
+}
+
+impl From<&DNSPacket> for Vec<u8> {
+    fn from(item: &DNSPacket) -> Self {
+        let mut v = Vec::new();
+        v.extend(Vec::<u8>::from(&item.header));
+        for qd in &item.qd {
+            v.extend(Vec::<u8>::from(qd));
+        }
+        for rr in &item.rr {
+            v.extend(Vec::<u8>::from(rr));
+        }
+        for ns in &item.ns {
+            v.extend(Vec::<u8>::from(ns));
+        }
+        for ar in &item.ar {
+            v.extend(Vec::<u8>::from(ar));
+        }
+        v
+    }
+}
+
+impl MPacket for DNSPacket {
+    fn new() -> Self {
+        DNSPacket {
+            d: PacketDissector::new(DNSState::Header),
+            header: DNSHeader::new(),
+            qd: Vec::new(),
+            rr: Vec::new(),
+            ns: Vec::new(),
+            ar: Vec::new(),
+        }
+    }
+
+    fn parse(&mut self, byte: &u8) {
+        match self.d.state {
+            DNSState::Header => {
+                self.header.parse(byte);
+                if self.header.d.state == DNSHeaderState::End {
+                    if self.header.qdcount > 0 {
+                        self.qd.push(DNSQuery::new());
+                        self.d.next_state(DNSState::Query);
+                    } else if self.header.ancount > 0 {
+                        self.rr.push(DNSRR::new());
+                        self.d.next_state(DNSState::Answer);
+                    } else if self.header.nscount > 0 {
+                        self.d.next_state(DNSState::Authority);
+                    } else if self.header.arcount > 0 {
+                        self.d.next_state(DNSState::Additional);
+                    } else {
+                        self.d.next_state(DNSState::End);
+                    }
+                }
+            }
+            DNSState::Query => {
+                let qdcount = self.qd.len();
+                self.qd[qdcount - 1].parse(byte);
+                if self.qd[qdcount - 1].d.state == DNSQueryState::End {
+                    if self.header.qdcount as usize > self.qd.len() {
+                        self.qd.push(DNSQuery::new());
+                    } else if self.header.ancount > 0 {
+                        self.rr.push(DNSRR::new());
+                        self.d.next_state(DNSState::Answer);
+                    } else if self.header.nscount > 0 {
+                        self.d.next_state(DNSState::Authority);
+                    } else if self.header.arcount > 0 {
+                        self.d.next_state(DNSState::Additional);
+                    } else {
+                        self.d.next_state(DNSState::End);
+                    }
+                }
+            }
+            DNSState::Answer => {
+                let ancount = self.rr.len();
+                self.rr[ancount - 1].parse(byte);
+                if self.rr[ancount - 1].d.state == DNSRRState::End {
+                    if self.header.ancount as usize > self.rr.len() {
+                        self.rr.push(DNSRR::new());
+                    } else if self.header.nscount > 0 {
+                        self.d.next_state(DNSState::Authority);
+                    } else if self.header.arcount > 0 {
+                        self.d.next_state(DNSState::Additional);
+                    } else {
+                        self.d.next_state(DNSState::End);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn repl(
+        &self,
+        masscanned: &Masscanned,
+        client_info: &ClientInfo,
+        _tcb: Option<&mut TCPControlBlock>,
+    ) -> Option<Vec<u8>> {
+        let mut ans = DNSPacket::new();
+        ans.header = if let Some(hdr) = self.header.repl(&masscanned, &client_info, None) {
+            if let Ok(h) = DNSHeader::try_from(hdr) {
+                h
+            } else {
+                return None;
+            }
+        } else {
+            return None;
+        };
+        /* reply to qd */
+        for qd in &self.qd {
+            if let Ok(q) = DNSQuery::try_from(Vec::<u8>::from(qd)) {
+                ans.qd.push(q);
+            } else {
+                return None;
+            }
+            if let Some(raw_rr) = qd.repl(&masscanned, &client_info, None) {
+                if let Ok(rr) = DNSRR::try_from(raw_rr) {
+                    ans.rr.push(rr);
+                } else {
+                    return None;
+                }
+            } else {
+                return None;
+            }
+        }
+        Some(Vec::<u8>::from(&ans))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::cst::{DNSClass, DNSType};
+    use super::*;
+
+    use pnet::util::MacAddr;
+    use std::net::{IpAddr, Ipv4Addr};
+    use std::str::FromStr;
+
+    use crate::logger::MetaLogger;
+
+    #[test]
+    fn parse_qd_all() {
+        /* OK */
+        /* scapy: DNS(id=0x1337,
+         * qd=DNSQR(qname="www.example1.com")/DNSQR(qname="www.example2.com")/DNSQR(qname="www.example3.com"))
+         **/
+        let payload = b"\x137\x01\x00\x00\x03\x00\x00\x00\x00\x00\x00\x03www\x08example1\x03com\x00\x00\x01\x00\x01\x03www\x08example2\x03com\x00\x00\x01\x00\x01\x03www\x08example3\x03com\x00\x00\x01\x00\x01";
+        let dns = match DNSPacket::try_from(payload.to_vec()) {
+            Ok(_dns) => _dns,
+            Err(e) => panic!("error while parsing DNS packet: {}", e),
+        };
+        assert!(dns.header.id == 0x1337);
+        assert!(dns.header._qr == false);
+        assert!(dns.header._opcode == 0);
+        assert!(dns.header._aa == false);
+        assert!(dns.header._tc == false);
+        assert!(dns.header._rd == true);
+        assert!(dns.header._ra == false);
+        assert!(dns.header._z == 0);
+        assert!(dns.header._rcode == 0);
+        assert!(dns.header.qdcount == 3);
+        assert!(dns.header.ancount == 0);
+        assert!(dns.header.nscount == 0);
+        assert!(dns.header.arcount == 0);
+        assert!(dns.qd.len() == 3);
+        assert!(
+            dns.qd[0].name
+                == [
+                    0x03, 0x77, 0x77, 0x77, 0x08, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x31,
+                    0x03, 0x63, 0x6f, 0x6d, 0x00
+                ]
+        );
+        assert!(dns.qd[0].type_ == DNSType::A);
+        assert!(dns.qd[0].class == DNSClass::IN);
+        assert!(
+            dns.qd[1].name
+                == [
+                    0x03, 0x77, 0x77, 0x77, 0x08, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x32,
+                    0x03, 0x63, 0x6f, 0x6d, 0x00
+                ]
+        );
+        assert!(dns.qd[1].type_ == DNSType::A);
+        assert!(dns.qd[1].class == DNSClass::IN);
+        assert!(
+            dns.qd[2].name
+                == [
+                    0x03, 0x77, 0x77, 0x77, 0x08, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x33,
+                    0x03, 0x63, 0x6f, 0x6d, 0x00
+                ]
+        );
+        assert!(dns.qd[2].type_ == DNSType::A);
+        assert!(dns.qd[2].class == DNSClass::IN);
+        /* KO */
+        let payload = b"\x137\x01\x00\x00\x03\x00\x00\x00\x00\x00\x00\x03www\x08example1\x03com\x00\x00\x01\x00\x01\x03www\x08example2\x03com\x00\x00\x01\x00\x01\x03www\x08example3\x03com\x00\x00\x01\x00";
+        match DNSPacket::try_from(payload.to_vec()) {
+            Ok(_) => panic!("parsing should have failed"),
+            Err(_) => {}
+        }
+        let payload = b"xxx";
+        match DNSPacket::try_from(payload.to_vec()) {
+            Ok(_) => panic!("parsing should have failed"),
+            Err(_) => {}
+        }
+    }
+
+    #[test]
+    fn parse_qd_byte_by_byte() {
+        /* scapy: DNS(id=0x1337,
+         * qd=DNSQR(qname="www.example1.com")/DNSQR(qname="www.example2.com")/DNSQR(qname="www.example3.com"))
+         **/
+        let payload = b"\x137\x01\x00\x00\x03\x00\x00\x00\x00\x00\x00\x03www\x08example1\x03com\x00\x00\x01\x00\x01\x03www\x08example2\x03com\x00\x00\x01\x00\x01\x03www\x08example3\x03com\x00\x00\x01\x00\x01";
+        let mut dns = DNSPacket::new();
+        for b in payload {
+            assert!(dns.d.state != DNSState::End);
+            dns.parse(&b);
+        }
+        assert!(dns.d.state == DNSState::End);
+        assert!(dns.header.id == 0x1337);
+        assert!(dns.header._qr == false);
+        assert!(dns.header._opcode == 0);
+        assert!(dns.header._aa == false);
+        assert!(dns.header._tc == false);
+        assert!(dns.header._rd == true);
+        assert!(dns.header._ra == false);
+        assert!(dns.header._z == 0);
+        assert!(dns.header._rcode == 0);
+        assert!(dns.header.qdcount == 3);
+        assert!(dns.header.ancount == 0);
+        assert!(dns.header.nscount == 0);
+        assert!(dns.header.arcount == 0);
+        assert!(dns.qd.len() == 3);
+        assert!(
+            dns.qd[0].name
+                == [
+                    0x03, 0x77, 0x77, 0x77, 0x08, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x31,
+                    0x03, 0x63, 0x6f, 0x6d, 0x00
+                ]
+        );
+        assert!(dns.qd[0].type_ == DNSType::A);
+        assert!(dns.qd[0].class == DNSClass::IN);
+        assert!(
+            dns.qd[1].name
+                == [
+                    0x03, 0x77, 0x77, 0x77, 0x08, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x32,
+                    0x03, 0x63, 0x6f, 0x6d, 0x00
+                ]
+        );
+        assert!(dns.qd[1].type_ == DNSType::A);
+        assert!(dns.qd[1].class == DNSClass::IN);
+        assert!(
+            dns.qd[2].name
+                == [
+                    0x03, 0x77, 0x77, 0x77, 0x08, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x33,
+                    0x03, 0x63, 0x6f, 0x6d, 0x00
+                ]
+        );
+        assert!(dns.qd[2].type_ == DNSType::A);
+        assert!(dns.qd[2].class == DNSClass::IN);
+    }
+
+    #[test]
+    fn parse_rr_all() {
+        /* OK */
+        /* scapy: DNS(id=1234, qr=True, aa=True, qd=None,
+         * an=DNSRR(rrname="www.example1.com", rdata="127.0.0.1")/DNSRR(rrname="www.example2.com", rdata="127.0.0.2")/DNSRR(rrname="www.example3.com", rdata="127.0.0.3"))
+         **/
+        let payload = b"\x04\xd2\x85\x00\x00\x00\x00\x03\x00\x00\x00\x00\x03www\x08example1\x03com\x00\x00\x01\x00\x01\x00\x00\x00\x00\x00\x04\x7f\x00\x00\x01\x03www\x08example2\x03com\x00\x00\x01\x00\x01\x00\x00\x00\x00\x00\x04\x7f\x00\x00\x02\x03www\x08example3\x03com\x00\x00\x01\x00\x01\x00\x00\x00\x00\x00\x04\x7f\x00\x00\x03";
+        let dns = match DNSPacket::try_from(payload.to_vec()) {
+            Ok(_dns) => _dns,
+            Err(e) => panic!("error while parsing DNS packet: {}", e),
+        };
+        assert!(dns.header.id == 1234);
+        assert!(dns.header._qr == true);
+        assert!(dns.header._opcode == 0);
+        assert!(dns.header._aa == true);
+        assert!(dns.header._tc == false);
+        assert!(dns.header._rd == true);
+        assert!(dns.header._ra == false);
+        assert!(dns.header._z == 0);
+        assert!(dns.header._rcode == 0);
+        assert!(dns.header.qdcount == 0);
+        assert!(dns.header.ancount == 3);
+        assert!(dns.header.nscount == 0);
+        assert!(dns.header.arcount == 0);
+        assert!(dns.rr.len() == 3);
+        assert!(
+            dns.rr[0].name
+                == [
+                    0x03, 0x77, 0x77, 0x77, 0x08, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x31,
+                    0x03, 0x63, 0x6f, 0x6d, 0x00
+                ]
+        );
+        assert!(dns.rr[0].type_ == DNSType::A);
+        assert!(dns.rr[0].class == DNSClass::IN);
+        assert!(dns.rr[0].rdata == [0x7f, 0x00, 0x00, 0x01]);
+        assert!(
+            dns.rr[1].name
+                == [
+                    0x03, 0x77, 0x77, 0x77, 0x08, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x32,
+                    0x03, 0x63, 0x6f, 0x6d, 0x00
+                ]
+        );
+        assert!(dns.rr[1].type_ == DNSType::A);
+        assert!(dns.rr[1].class == DNSClass::IN);
+        assert!(dns.rr[1].rdata == [0x7f, 0x00, 0x00, 0x02]);
+        assert!(
+            dns.rr[2].name
+                == [
+                    0x03, 0x77, 0x77, 0x77, 0x08, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x33,
+                    0x03, 0x63, 0x6f, 0x6d, 0x00
+                ]
+        );
+        assert!(dns.rr[2].type_ == DNSType::A);
+        assert!(dns.rr[2].class == DNSClass::IN);
+        assert!(dns.rr[2].rdata == [0x7f, 0x00, 0x00, 0x03]);
+        /* KO */
+        let payload = b"\x04\xd2\x85\x00\x00\x00\x00\x04\x00\x00\x00\x00\x03www\x08example1\x03com\x00\x00\x01\x00\x01\x00\x00\x00\x00\x00\x04\x7f\x00\x00\x01\x03www\x08example2\x03com\x00\x00\x01\x00\x01\x00\x00\x00\x00\x00\x04\x7f\x00\x00\x02\x03www\x08example3\x03com\x00\x00\x01\x00\x01\x00\x00\x00\x00\x00\x04\x7f\x00\x00\x03";
+        match DNSPacket::try_from(payload.to_vec()) {
+            Ok(_) => panic!("parsing should have failed"),
+            Err(_) => {}
+        }
+        let payload = b"xxx";
+        match DNSPacket::try_from(payload.to_vec()) {
+            Ok(_) => panic!("parsing should have failed"),
+            Err(_) => {}
+        }
+    }
+
+    #[test]
+    fn parse_rr_byte_by_byte() {
+        /* scapy: DNS(id=1234, qr=True, aa=True, qd=None,
+         * an=DNSRR(rrname="www.example1.com", rdata="127.0.0.1")/DNSRR(rrname="www.example2.com", rdata="127.0.0.2")/DNSRR(rrname="www.example3.com", rdata="127.0.0.3"))
+         **/
+        let payload = b"\x04\xd2\x85\x00\x00\x00\x00\x03\x00\x00\x00\x00\x03www\x08example1\x03com\x00\x00\x01\x00\x01\x00\x00\x00\x00\x00\x04\x7f\x00\x00\x01\x03www\x08example2\x03com\x00\x00\x01\x00\x01\x00\x00\x00\x00\x00\x04\x7f\x00\x00\x02\x03www\x08example3\x03com\x00\x00\x01\x00\x01\x00\x00\x00\x00\x00\x04\x7f\x00\x00\x03";
+        let mut dns = DNSPacket::new();
+        for b in payload {
+            assert!(dns.d.state != DNSState::End);
+            dns.parse(&b);
+        }
+        assert!(dns.d.state == DNSState::End);
+        assert!(dns.header.id == 1234);
+        assert!(dns.header._qr == true);
+        assert!(dns.header._opcode == 0);
+        assert!(dns.header._aa == true);
+        assert!(dns.header._tc == false);
+        assert!(dns.header._rd == true);
+        assert!(dns.header._ra == false);
+        assert!(dns.header._z == 0);
+        assert!(dns.header._rcode == 0);
+        assert!(dns.header.qdcount == 0);
+        assert!(dns.header.ancount == 3);
+        assert!(dns.header.nscount == 0);
+        assert!(dns.header.arcount == 0);
+        assert!(dns.rr.len() == 3);
+        assert!(
+            dns.rr[0].name
+                == [
+                    0x03, 0x77, 0x77, 0x77, 0x08, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x31,
+                    0x03, 0x63, 0x6f, 0x6d, 0x00
+                ]
+        );
+        assert!(dns.rr[0].type_ == DNSType::A);
+        assert!(dns.rr[0].class == DNSClass::IN);
+        assert!(dns.rr[0].rdata == [0x7f, 0x00, 0x00, 0x01]);
+        assert!(
+            dns.rr[1].name
+                == [
+                    0x03, 0x77, 0x77, 0x77, 0x08, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x32,
+                    0x03, 0x63, 0x6f, 0x6d, 0x00
+                ]
+        );
+        assert!(dns.rr[1].type_ == DNSType::A);
+        assert!(dns.rr[1].class == DNSClass::IN);
+        assert!(dns.rr[1].rdata == [0x7f, 0x00, 0x00, 0x02]);
+        assert!(
+            dns.rr[2].name
+                == [
+                    0x03, 0x77, 0x77, 0x77, 0x08, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x33,
+                    0x03, 0x63, 0x6f, 0x6d, 0x00
+                ]
+        );
+        assert!(dns.rr[2].type_ == DNSType::A);
+        assert!(dns.rr[2].class == DNSClass::IN);
+        assert!(dns.rr[2].rdata == [0x7f, 0x00, 0x00, 0x03]);
+    }
+
+    #[test]
+    fn parse_qd_rr_all() {
+        /* scapy: DNS(id=1234, qr=True, aa=True,
+         * qd=DNSQR(qname="www.example1.com")/DNSQR(qname="www.example2.com")/DNSQR(qname="www.example3.com"),
+         * an=DNSRR(rrname="www.example1.com", rdata="127.0.0.1")/DNSRR(rrname="www.example2.com", rdata="127.0.0.2")/DNSRR(rrname="www.example3.com", rdata="127.0.0.3"))
+         */
+        let payload = b"\x04\xd2\x85\x00\x00\x03\x00\x03\x00\x00\x00\x00\x03www\x08example1\x03com\x00\x00\x01\x00\x01\x03www\x08example2\x03com\x00\x00\x01\x00\x01\x03www\x08example3\x03com\x00\x00\x01\x00\x01\x03www\x08example1\x03com\x00\x00\x01\x00\x01\x00\x00\x00\x00\x00\x04\x7f\x00\x00\x01\x03www\x08example2\x03com\x00\x00\x01\x00\x01\x00\x00\x00\x00\x00\x04\x7f\x00\x00\x02\x03www\x08example3\x03com\x00\x00\x01\x00\x01\x00\x00\x00\x00\x00\x04\x7f\x00\x00\x03";
+        let dns = match DNSPacket::try_from(payload.to_vec()) {
+            Ok(_dns) => _dns,
+            Err(e) => panic!("error while parsing DNS packet: {}", e),
+        };
+        assert!(dns.header.id == 1234);
+        assert!(dns.header._qr == true);
+        assert!(dns.header._opcode == 0);
+        assert!(dns.header._aa == true);
+        assert!(dns.header._tc == false);
+        assert!(dns.header._rd == true);
+        assert!(dns.header._ra == false);
+        assert!(dns.header._z == 0);
+        assert!(dns.header._rcode == 0);
+        assert!(dns.header.qdcount == 3);
+        assert!(dns.header.ancount == 3);
+        assert!(dns.header.nscount == 0);
+        assert!(dns.header.arcount == 0);
+        assert!(dns.qd.len() == 3);
+        assert!(
+            dns.qd[0].name
+                == [
+                    0x03, 0x77, 0x77, 0x77, 0x08, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x31,
+                    0x03, 0x63, 0x6f, 0x6d, 0x00
+                ]
+        );
+        assert!(dns.qd[0].type_ == DNSType::A);
+        assert!(dns.qd[0].class == DNSClass::IN);
+        assert!(
+            dns.qd[1].name
+                == [
+                    0x03, 0x77, 0x77, 0x77, 0x08, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x32,
+                    0x03, 0x63, 0x6f, 0x6d, 0x00
+                ]
+        );
+        assert!(dns.qd[1].type_ == DNSType::A);
+        assert!(dns.qd[1].class == DNSClass::IN);
+        assert!(
+            dns.qd[2].name
+                == [
+                    0x03, 0x77, 0x77, 0x77, 0x08, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x33,
+                    0x03, 0x63, 0x6f, 0x6d, 0x00
+                ]
+        );
+        assert!(dns.qd[2].type_ == DNSType::A);
+        assert!(dns.qd[2].class == DNSClass::IN);
+        assert!(dns.rr.len() == 3);
+        assert!(
+            dns.rr[0].name
+                == [
+                    0x03, 0x77, 0x77, 0x77, 0x08, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x31,
+                    0x03, 0x63, 0x6f, 0x6d, 0x00
+                ]
+        );
+        assert!(dns.rr[0].type_ == DNSType::A);
+        assert!(dns.rr[0].class == DNSClass::IN);
+        assert!(dns.rr[0].rdata == [0x7f, 0x00, 0x00, 0x01]);
+        assert!(
+            dns.rr[1].name
+                == [
+                    0x03, 0x77, 0x77, 0x77, 0x08, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x32,
+                    0x03, 0x63, 0x6f, 0x6d, 0x00
+                ]
+        );
+        assert!(dns.rr[1].type_ == DNSType::A);
+        assert!(dns.rr[1].class == DNSClass::IN);
+        assert!(dns.rr[1].rdata == [0x7f, 0x00, 0x00, 0x02]);
+        assert!(
+            dns.rr[2].name
+                == [
+                    0x03, 0x77, 0x77, 0x77, 0x08, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x33,
+                    0x03, 0x63, 0x6f, 0x6d, 0x00
+                ]
+        );
+        assert!(dns.rr[2].type_ == DNSType::A);
+        assert!(dns.rr[2].class == DNSClass::IN);
+        assert!(dns.rr[2].rdata == [0x7f, 0x00, 0x00, 0x03]);
+    }
+
+    #[test]
+    fn parse_qr_rr_byte_by_byte() {
+        /* scapy: DNS(id=1234, qr=True, aa=True,
+         * qd=DNSQR(qname="www.example1.com")/DNSQR(qname="www.example2.com")/DNSQR(qname="www.example3.com"),
+         * an=DNSRR(rrname="www.example1.com", rdata="127.0.0.1")/DNSRR(rrname="www.example2.com", rdata="127.0.0.2")/DNSRR(rrname="www.example3.com", rdata="127.0.0.3"))
+         */
+        let payload = b"\x04\xd2\x85\x00\x00\x03\x00\x03\x00\x00\x00\x00\x03www\x08example1\x03com\x00\x00\x01\x00\x01\x03www\x08example2\x03com\x00\x00\x01\x00\x01\x03www\x08example3\x03com\x00\x00\x01\x00\x01\x03www\x08example1\x03com\x00\x00\x01\x00\x01\x00\x00\x00\x00\x00\x04\x7f\x00\x00\x01\x03www\x08example2\x03com\x00\x00\x01\x00\x01\x00\x00\x00\x00\x00\x04\x7f\x00\x00\x02\x03www\x08example3\x03com\x00\x00\x01\x00\x01\x00\x00\x00\x00\x00\x04\x7f\x00\x00\x03";
+        let mut dns = DNSPacket::new();
+        for b in payload {
+            assert!(dns.d.state != DNSState::End);
+            dns.parse(&b);
+        }
+        assert!(dns.d.state == DNSState::End);
+        assert!(dns.header.id == 1234);
+        assert!(dns.header._qr == true);
+        assert!(dns.header._opcode == 0);
+        assert!(dns.header._aa == true);
+        assert!(dns.header._tc == false);
+        assert!(dns.header._rd == true);
+        assert!(dns.header._ra == false);
+        assert!(dns.header._z == 0);
+        assert!(dns.header._rcode == 0);
+        assert!(dns.header.qdcount == 3);
+        assert!(dns.header.ancount == 3);
+        assert!(dns.header.nscount == 0);
+        assert!(dns.header.arcount == 0);
+        assert!(dns.qd.len() == 3);
+        assert!(
+            dns.qd[0].name
+                == [
+                    0x03, 0x77, 0x77, 0x77, 0x08, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x31,
+                    0x03, 0x63, 0x6f, 0x6d, 0x00
+                ]
+        );
+        assert!(dns.qd[0].type_ == DNSType::A);
+        assert!(dns.qd[0].class == DNSClass::IN);
+        assert!(
+            dns.qd[1].name
+                == [
+                    0x03, 0x77, 0x77, 0x77, 0x08, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x32,
+                    0x03, 0x63, 0x6f, 0x6d, 0x00
+                ]
+        );
+        assert!(dns.qd[1].type_ == DNSType::A);
+        assert!(dns.qd[1].class == DNSClass::IN);
+        assert!(
+            dns.qd[2].name
+                == [
+                    0x03, 0x77, 0x77, 0x77, 0x08, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x33,
+                    0x03, 0x63, 0x6f, 0x6d, 0x00
+                ]
+        );
+        assert!(dns.qd[2].type_ == DNSType::A);
+        assert!(dns.qd[2].class == DNSClass::IN);
+        assert!(dns.rr.len() == 3);
+        assert!(
+            dns.rr[0].name
+                == [
+                    0x03, 0x77, 0x77, 0x77, 0x08, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x31,
+                    0x03, 0x63, 0x6f, 0x6d, 0x00
+                ]
+        );
+        assert!(dns.rr[0].type_ == DNSType::A);
+        assert!(dns.rr[0].class == DNSClass::IN);
+        assert!(dns.rr[0].rdata == [0x7f, 0x00, 0x00, 0x01]);
+        assert!(
+            dns.rr[1].name
+                == [
+                    0x03, 0x77, 0x77, 0x77, 0x08, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x32,
+                    0x03, 0x63, 0x6f, 0x6d, 0x00
+                ]
+        );
+        assert!(dns.rr[1].type_ == DNSType::A);
+        assert!(dns.rr[1].class == DNSClass::IN);
+        assert!(dns.rr[1].rdata == [0x7f, 0x00, 0x00, 0x02]);
+        assert!(
+            dns.rr[2].name
+                == [
+                    0x03, 0x77, 0x77, 0x77, 0x08, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x33,
+                    0x03, 0x63, 0x6f, 0x6d, 0x00
+                ]
+        );
+        assert!(dns.rr[2].type_ == DNSType::A);
+        assert!(dns.rr[2].class == DNSClass::IN);
+        assert!(dns.rr[2].rdata == [0x7f, 0x00, 0x00, 0x03]);
+    }
+
+    #[test]
+    fn reply_in_a() {
+        let masscanned = Masscanned {
+            synack_key: [0, 0],
+            mac: MacAddr::from_str("00:00:00:00:00:00").expect("error parsing default MAC address"),
+            iface: None,
+            ip_addresses: None,
+            log: MetaLogger::new(),
+        };
+        let mut client_info = ClientInfo::new();
+        /* scapy: DNS(id=0x1337,
+         * qd=DNSQR(qname="www.example.com"))
+         **/
+        let payload = b"\x137\x01\x00\x00\x01\x00\x00\x00\x00\x00\x00\x03www\x07example\x03com\x00\x00\x01\x00\x01";
+        let dns = DNSPacket::try_from(payload.to_vec()).unwrap();
+        for ip in [
+            Ipv4Addr::new(127, 0, 0, 1),
+            Ipv4Addr::new(0, 0, 0, 0),
+            Ipv4Addr::new(4, 3, 2, 1),
+        ] {
+            client_info.ip.dst = Some(IpAddr::V4(ip));
+            let ans = if let Some(a) = dns.repl(&masscanned, &client_info, None) {
+                DNSPacket::try_from(a).unwrap()
+            } else {
+                panic!("expected a reply, got None");
+            };
+            assert!(ans.header.id == 0x1337);
+            assert!(ans.header._qr == true);
+            assert!(ans.header._opcode == 0);
+            assert!(ans.header._aa == true);
+            assert!(ans.header._tc == false);
+            assert!(ans.header._rd == dns.header._rd);
+            assert!(ans.header._ra == false);
+            assert!(ans.header._z == 0);
+            assert!(ans.header._rcode == 0);
+            assert!(ans.header.qdcount == 1);
+            assert!(ans.header.ancount == 1);
+            assert!(ans.header.nscount == 0);
+            assert!(ans.header.arcount == 0);
+            assert!(ans.qd.len() == 1);
+            assert!(
+                ans.qd[0].name
+                    == [
+                        0x03, 0x77, 0x77, 0x77, 0x07, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65,
+                        0x03, 0x63, 0x6f, 0x6d, 0x00
+                    ]
+            );
+            assert!(ans.qd[0].type_ == DNSType::A);
+            assert!(ans.qd[0].class == DNSClass::IN);
+            assert!(ans.rr.len() == 1);
+            assert!(
+                ans.rr[0].name
+                    == [
+                        0x03, 0x77, 0x77, 0x77, 0x07, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65,
+                        0x03, 0x63, 0x6f, 0x6d, 0x00
+                    ]
+            );
+            assert!(ans.rr[0].type_ == DNSType::A);
+            assert!(ans.rr[0].class == DNSClass::IN);
+            assert!(ans.rr[0].rdata == ip.octets());
+        }
+    }
+}

--- a/src/proto/dns/query.rs
+++ b/src/proto/dns/query.rs
@@ -1,0 +1,335 @@
+// This file is part of masscanned.
+// Copyright 2022 - The IVRE project
+//
+// Masscanned is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Masscanned is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+// License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Masscanned. If not, see <http://www.gnu.org/licenses/>.
+
+use super::cst::{DNSClass, DNSType};
+use super::rr::DNSRR;
+
+use std::convert::TryFrom;
+use std::net::IpAddr;
+
+use crate::proto::dissector::{MPacket, PacketDissector};
+use crate::proto::ClientInfo;
+use crate::proto::TCPControlBlock;
+use crate::Masscanned;
+
+#[derive(PartialEq)]
+pub enum DNSQueryState {
+    Name,
+    Type,
+    Class,
+    End,
+}
+
+pub struct DNSQuery {
+    pub d: PacketDissector<DNSQueryState>,
+    /* RFC 1035 - Section 4.1.2 */
+    pub name: Vec<u8>,
+    _u_type: u16,
+    pub type_: DNSType,
+    _u_class: u16,
+    pub class: DNSClass,
+}
+
+impl TryFrom<Vec<u8>> for DNSQuery {
+    type Error = &'static str;
+
+    fn try_from(item: Vec<u8>) -> Result<Self, Self::Error> {
+        let mut query = DNSQuery::new();
+        for b in item {
+            query.parse(&b);
+        }
+        if query.d.state == DNSQueryState::End {
+            Ok(query)
+        } else {
+            Err("packet is incomplete")
+        }
+    }
+}
+
+impl From<&DNSQuery> for Vec<u8> {
+    fn from(item: &DNSQuery) -> Self {
+        let mut v = Vec::new();
+        /* name */
+        v.extend(&item.name);
+        /* type */
+        v.push(((u16::from(item.type_)) >> 8) as u8);
+        v.push(((u16::from(item.type_)) & 0xFF) as u8);
+        /* class */
+        v.push(((u16::from(item.class)) >> 8) as u8);
+        v.push(((u16::from(item.class)) & 0xFF) as u8);
+        /* return */
+        v
+    }
+}
+
+impl MPacket for DNSQuery {
+    fn new() -> Self {
+        DNSQuery {
+            d: PacketDissector::new(DNSQueryState::Name),
+            name: Vec::new(),
+            _u_type: 0,
+            type_: DNSType::NONE,
+            _u_class: 0,
+            class: DNSClass::NONE,
+        }
+    }
+
+    fn parse(&mut self, byte: &u8) {
+        match self.d.state {
+            DNSQueryState::Name => {
+                self.name.push(*byte);
+                if *byte == 0 {
+                    self.d.next_state(DNSQueryState::Type);
+                }
+            }
+            DNSQueryState::Type => {
+                self._u_type = self.d.read_u16(byte, self._u_type, DNSQueryState::Class);
+            }
+            DNSQueryState::Class => {
+                self._u_class = self.d.read_u16(byte, self._u_class, DNSQueryState::End);
+            }
+            DNSQueryState::End => {}
+        }
+        /* we need this to be executed at the same call
+         * the state changes to End, hence it is not in the
+         * match structure
+         **/
+        if self.d.state == DNSQueryState::End {
+            self.type_ = DNSType::from(self._u_type);
+            self.class = DNSClass::from(self._u_class);
+        }
+    }
+
+    fn repl(
+        &self,
+        _masscanned: &Masscanned,
+        client_info: &ClientInfo,
+        _tcb: Option<&mut TCPControlBlock>,
+    ) -> Option<Vec<u8>> {
+        match self.class {
+            DNSClass::IN => {
+                match self.type_ {
+                    DNSType::A => {
+                        let mut rr = DNSRR::new();
+                        /* copy request */
+                        for b in &self.name {
+                            rr.name.push(*b);
+                        }
+                        rr.type_ = DNSType::A;
+                        rr.class = DNSClass::IN;
+                        rr.ttl = 43200;
+                        rr.rdata = match client_info.ip.dst {
+                            Some(IpAddr::V4(ip)) => ip.octets().to_vec(),
+                            Some(IpAddr::V6(_)) => Vec::new(),
+                            None => Vec::new(),
+                        };
+                        rr.rdlen = rr.rdata.len() as u16;
+                        Some(Vec::<u8>::from(&rr))
+                    }
+                    _ => None,
+                }
+            }
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use pnet::util::MacAddr;
+    use std::net::{IpAddr, Ipv4Addr};
+    use std::str::FromStr;
+    use strum::IntoEnumIterator;
+
+    use crate::client::ClientInfoSrcDst;
+    use crate::logger::MetaLogger;
+
+    #[test]
+    fn parse_in_a_all() {
+        /* A */
+        let payload = b"\x03www\x07example\x03com\x00\x00\x01\x00\x01";
+        let qr = match DNSQuery::try_from(payload.to_vec()) {
+            Ok(_qr) => _qr,
+            Err(e) => panic!("error while parsing DNS query: {}", e),
+        };
+        assert!(
+            qr.name
+                == [
+                    0x03, 0x77, 0x77, 0x77, 0x07, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x03,
+                    0x63, 0x6f, 0x6d, 0x00
+                ]
+        );
+        assert!(qr.type_ == DNSType::A);
+        assert!(qr.class == DNSClass::IN);
+        assert!(Vec::<u8>::from(&qr) == payload.to_vec());
+        /* TXT */
+        let payload = b"\x07version\x04bind\x00\x00\x10\x00\x03";
+        let qr = match DNSQuery::try_from(payload.to_vec()) {
+            Ok(_qr) => _qr,
+            Err(e) => panic!("error while parsing DNS query: {}", e),
+        };
+        assert!(qr.type_ == DNSType::TXT);
+        assert!(qr.class == DNSClass::CH);
+        assert!(Vec::<u8>::from(&qr) == payload.to_vec());
+        /* KO */
+        let payload = b"xxx";
+        match DNSQuery::try_from(payload.to_vec()) {
+            Ok(_) => panic!("parsing should have failed"),
+            Err(_) => {}
+        }
+    }
+
+    #[test]
+    fn parse_in_a_byte_by_byte() {
+        /* A */
+        let payload = b"\x03www\x07example\x03com\x00\x00\x01\x00\x01";
+        let mut qr = DNSQuery::new();
+        for b in payload {
+            qr.parse(b);
+        }
+        assert!(qr.d.state == DNSQueryState::End);
+        assert!(
+            qr.name
+                == [
+                    0x03, 0x77, 0x77, 0x77, 0x07, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x03,
+                    0x63, 0x6f, 0x6d, 0x00
+                ]
+        );
+        assert!(qr.type_ == DNSType::A);
+        assert!(qr.class == DNSClass::IN);
+        assert!(Vec::<u8>::from(&qr) == payload.to_vec());
+        /* TXT */
+        let payload = b"\x07version\x04bind\x00\x00\x10\x00\x03";
+        let mut qr = DNSQuery::new();
+        for b in payload {
+            qr.parse(b);
+        }
+        assert!(qr.d.state == DNSQueryState::End);
+        assert!(qr.type_ == DNSType::TXT);
+        assert!(qr.class == DNSClass::CH);
+        assert!(Vec::<u8>::from(&qr) == payload.to_vec());
+        /* KO */
+        let payload = b"xxx";
+        let mut qr = DNSQuery::new();
+        for b in payload {
+            qr.parse(b);
+        }
+        assert!(qr.d.state != DNSQueryState::End);
+    }
+
+    #[test]
+    fn reply_in_a() {
+        let masscanned = Masscanned {
+            synack_key: [0, 0],
+            mac: MacAddr::from_str("00:00:00:00:00:00").expect("error parsing default MAC address"),
+            iface: None,
+            ip_addresses: None,
+            log: MetaLogger::new(),
+        };
+        let ip_src = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
+        let ip_dst = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2));
+        let client_info = ClientInfo {
+            mac: ClientInfoSrcDst {
+                src: None,
+                dst: None,
+            },
+            ip: ClientInfoSrcDst {
+                src: Some(ip_src),
+                dst: Some(ip_dst),
+            },
+            transport: None,
+            port: ClientInfoSrcDst {
+                src: None,
+                dst: None,
+            },
+            cookie: None,
+        };
+        /* TXT */
+        let payload = b"\x07version\x04bind\x00\x00\x10\x00\x03";
+        let mut qr = DNSQuery::new();
+        for b in payload {
+            qr.parse(b);
+        }
+        assert!(qr.type_ == DNSType::TXT);
+        assert!(qr.class == DNSClass::CH);
+        /* A */
+        let payload = b"\x03www\x07example\x03com\x00\x00\x01\x00\x01";
+        let mut qr = DNSQuery::new();
+        for b in payload {
+            qr.parse(b);
+        }
+        assert!(
+            qr.name
+                == [
+                    0x03, 0x77, 0x77, 0x77, 0x07, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x03,
+                    0x63, 0x6f, 0x6d, 0x00
+                ]
+        );
+        assert!(qr.type_ == DNSType::A);
+        assert!(qr.class == DNSClass::IN);
+        let rr_raw = match qr.repl(&masscanned, &client_info, None) {
+            None => {
+                panic!()
+            }
+            Some(r) => r,
+        };
+        let mut rr = DNSRR::new();
+        for b in rr_raw {
+            rr.parse(&b);
+        }
+        assert!(rr.name == qr.name);
+        assert!(rr.type_ == DNSType::A);
+        assert!(rr.class == DNSClass::IN);
+        assert!(rr.ttl == 43200);
+        assert!(rr.rdata == [127, 0, 0, 2]);
+    }
+
+    #[test]
+    fn repl() {
+        let masscanned = Masscanned {
+            synack_key: [0, 0],
+            mac: MacAddr::from_str("00:00:00:00:00:00").expect("error parsing default MAC address"),
+            iface: None,
+            ip_addresses: None,
+            log: MetaLogger::new(),
+        };
+        let client_info = ClientInfo::new();
+        /* exhaustive tests */
+        let supported: Vec<(DNSClass, DNSType)> = vec![(DNSClass::IN, DNSType::A)];
+        let mut qd = DNSQuery::new();
+        qd.name = vec![
+            0x03, 0x77, 0x77, 0x77, 0x07, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x03, 0x63,
+            0x6f, 0x6d, 0x00,
+        ];
+        for c in DNSClass::iter() {
+            qd.class = c;
+            for t in DNSType::iter() {
+                qd.type_ = t;
+                if supported.contains(&(c, t)) {
+                    if qd.repl(&masscanned, &client_info, None) == None {
+                        panic!("expected reply, got None");
+                    }
+                } else {
+                    if qd.repl(&masscanned, &client_info, None) != None {
+                        panic!("expected no reply, got one for {:?}, {:?}", c, t);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/proto/dns/rr.rs
+++ b/src/proto/dns/rr.rs
@@ -1,0 +1,251 @@
+// This file is part of masscanned.
+// Copyright 2022 - The IVRE project
+//
+// Masscanned is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Masscanned is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+// License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Masscanned. If not, see <http://www.gnu.org/licenses/>.
+
+use super::cst::{DNSClass, DNSType};
+
+use std::convert::TryFrom;
+
+use crate::proto::dissector::{MPacket, PacketDissector};
+use crate::proto::ClientInfo;
+use crate::proto::TCPControlBlock;
+use crate::Masscanned;
+
+#[derive(PartialEq, Debug)]
+pub enum DNSRRState {
+    Name,
+    Type,
+    Class,
+    TTL,
+    RDLength,
+    RData,
+    End,
+}
+
+pub struct DNSRR {
+    pub d: PacketDissector<DNSRRState>,
+    /* RFC 1035 - Section 3.2.1 */
+    pub name: Vec<u8>,
+    _u_type: u16,
+    pub type_: DNSType,
+    _u_class: u16,
+    pub class: DNSClass,
+    pub ttl: u32,
+    pub rdlen: u16,
+    pub rdata: Vec<u8>,
+}
+
+impl From<&DNSRR> for Vec<u8> {
+    fn from(item: &DNSRR) -> Self {
+        /* CAUTION: for the rdlen field:
+         * - if item.rdlen is not 0, its value is packed
+         * - if item.rdlen = 0, then the length of item.rdata is used instead
+         */
+        let mut v = Vec::new();
+        /* name */
+        for b in &item.name {
+            v.push(b.clone());
+        }
+        /* type */
+        let type_: u16 = item.type_.into();
+        v.push((type_ >> 8) as u8);
+        v.push((type_ & 0xFF) as u8);
+        /* class */
+        let class: u16 = item.class.into();
+        v.push((class >> 8) as u8);
+        v.push((class & 0xFF) as u8);
+        /* ttl */
+        v.push((item.ttl >> 24) as u8);
+        v.push((item.ttl >> 16) as u8);
+        v.push((item.ttl >> 8) as u8);
+        v.push((item.ttl & 0xFF) as u8);
+        /* rdlen */
+        let rdlen = if item.rdlen == 0 {
+            item.rdata.len() as u16
+        } else {
+            item.rdlen
+        };
+        v.push((rdlen >> 8) as u8);
+        v.push((rdlen & 0xFF) as u8);
+        /* rdata */
+        for b in &item.rdata {
+            v.push(b.clone());
+        }
+        v
+    }
+}
+
+impl TryFrom<Vec<u8>> for DNSRR {
+    type Error = &'static str;
+
+    fn try_from(item: Vec<u8>) -> Result<Self, Self::Error> {
+        let mut rr = DNSRR::new();
+        for b in item {
+            rr.parse(&b);
+        }
+        if rr.d.state == DNSRRState::End {
+            Ok(rr)
+        } else {
+            Err("packet is incomplete")
+        }
+    }
+}
+
+impl MPacket for DNSRR {
+    fn new() -> Self {
+        DNSRR {
+            d: PacketDissector::new(DNSRRState::Name),
+            name: Vec::new(),
+            _u_type: 0,
+            type_: DNSType::NONE,
+            _u_class: 0,
+            class: DNSClass::NONE,
+            rdlen: 0,
+            ttl: 0,
+            rdata: Vec::new(),
+        }
+    }
+
+    fn parse(&mut self, byte: &u8) {
+        match self.d.state {
+            DNSRRState::Name => {
+                self.name.push(*byte);
+                if *byte == 0 {
+                    self.d.next_state(DNSRRState::Type);
+                }
+            }
+            DNSRRState::Type => {
+                self._u_type = self.d.read_u16(byte, self._u_type, DNSRRState::Class);
+            }
+            DNSRRState::Class => {
+                self._u_class = self.d.read_u16(byte, self._u_class, DNSRRState::TTL);
+            }
+            DNSRRState::TTL => {
+                self.ttl = self.d.read_u32(byte, self.ttl, DNSRRState::RDLength);
+            }
+            DNSRRState::RDLength => {
+                self.rdlen = self.d.read_u16(byte, self.rdlen, DNSRRState::RData);
+                /* when read the rdlen, check if len is 0 */
+                if self.d.state == DNSRRState::RData && self.rdlen == 0 {
+                    self.d.state = DNSRRState::End;
+                }
+            }
+            DNSRRState::RData => {
+                self.rdata.push(*byte);
+                if self.rdata.len() == self.rdlen as usize {
+                    self.d.next_state(DNSRRState::End);
+                }
+            }
+            DNSRRState::End => {}
+        }
+        /* we need this to be executed at the same call
+         * the state changes to End, hence it is not in the
+         * match structure
+         **/
+        if self.d.state == DNSRRState::End {
+            self.type_ = DNSType::from(self._u_type);
+            self.class = DNSClass::from(self._u_class);
+        }
+    }
+
+    fn repl(
+        &self,
+        _masscanned: &Masscanned,
+        _client_info: &ClientInfo,
+        _tcb: Option<&mut TCPControlBlock>,
+    ) -> Option<Vec<u8>> {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build() {
+        let mut rr = DNSRR::new();
+        rr.name = b"\x03www\x07example\x03com\x00".to_vec();
+        rr.class = DNSClass::IN;
+        rr.type_ = DNSType::A;
+        rr.ttl = 1234;
+        rr.rdlen = 4;
+        rr.rdata = b"\x7f\x00\x00\x01".to_vec();
+        assert!(Vec::<u8>::from(&rr) == b"\x03www\x07example\x03com\x00\x00\x01\x00\x01\x00\x00\x04\xd2\x00\x04\x7f\x00\x00\x01");
+    }
+
+    #[test]
+    fn parse_all() {
+        /*
+         * raw(DNSRR(rrname="www.example.com", rdata="127.0.0.1"))
+         */
+        let payload = b"\x03www\x07example\x03com\x00\x00\x01\x00\x01\x00\x00\x00\x00\x00\x04\x7f\x00\x00\x01";
+        let rr = match DNSRR::try_from(payload.to_vec()) {
+            Ok(r) => r,
+            Err(e) => panic!("error while parsing DNS RR: {}", e),
+        };
+        assert!(rr.name == b"\x03www\x07example\x03com\x00");
+        assert!(rr.class == DNSClass::IN);
+        assert!(rr.type_ == DNSType::A);
+        assert!(rr.rdata == b"\x7f\x00\x00\x01");
+        assert!(Vec::<u8>::from(&rr) == payload.to_vec());
+        /*
+         * empty data
+         */
+        let payload = b"\x03www\x07example\x03com\x00\x00\x01\x00\x01\x00\x00\x00\x00\x00\x00";
+        let rr = match DNSRR::try_from(payload.to_vec()) {
+            Ok(r) => r,
+            Err(e) => panic!("error while parsing DNS RR: {}", e),
+        };
+        assert!(rr.name == b"\x03www\x07example\x03com\x00");
+        assert!(rr.class == DNSClass::IN);
+        assert!(rr.type_ == DNSType::A);
+        assert!(rr.rdata == b"");
+        assert!(Vec::<u8>::from(&rr) == payload.to_vec());
+    }
+
+    #[test]
+    fn parse_byte_by_byte() {
+        /*
+         * raw(DNSRR(rrname="www.example.com", rdata="127.0.0.1"))
+         */
+        let payload = b"\x03www\x07example\x03com\x00\x00\x01\x00\x01\x00\x00\x00\x00\x00\x04\x7f\x00\x00\x01";
+        let mut rr = DNSRR::new();
+        for b in payload {
+            assert!(rr.d.state != DNSRRState::End);
+            rr.parse(b);
+        }
+        assert!(rr.d.state == DNSRRState::End);
+        assert!(rr.name == b"\x03www\x07example\x03com\x00");
+        assert!(rr.class == DNSClass::IN);
+        assert!(rr.type_ == DNSType::A);
+        assert!(rr.rdata == b"\x7f\x00\x00\x01");
+        assert!(Vec::<u8>::from(&rr) == payload.to_vec());
+        /*
+         * empty data
+         */
+        let payload = b"\x03www\x07example\x03com\x00\x00\x01\x00\x01\x00\x00\x00\x00\x00\x00";
+        let mut rr = DNSRR::new();
+        for b in payload {
+            assert!(rr.d.state != DNSRRState::End);
+            rr.parse(b);
+        }
+        assert!(rr.name == b"\x03www\x07example\x03com\x00");
+        assert!(rr.class == DNSClass::IN);
+        assert!(rr.type_ == DNSType::A);
+        assert!(rr.rdata == b"");
+        assert!(Vec::<u8>::from(&rr) == payload.to_vec());
+    }
+}

--- a/test/src/all.py
+++ b/test/src/all.py
@@ -22,6 +22,7 @@ from .core import test_all  # noqa: F401
 
 DEFAULT_TESTS = [
     "arp",
+    "dns",
     "ghost",
     "http",
     "icmpv4",

--- a/test/src/tests/dns.py
+++ b/test/src/tests/dns.py
@@ -1,0 +1,202 @@
+# This file is part of masscanned.
+# Copyright 2022 - The IVRE project
+#
+# Masscanned is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Masscanned is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Masscanned. If not, see <http://www.gnu.org/licenses/>.
+
+from socket import AF_INET6
+import struct
+
+from scapy.layers.dns import DNS, DNSQR
+from scapy.layers.inet import IP, UDP
+from scapy.layers.inet6 import IPv6
+from scapy.layers.l2 import Ether
+from scapy.packet import Raw
+from scapy.pton_ntop import inet_pton
+from scapy.sendrecv import srp1
+
+from ..conf import IPV4_ADDR, IPV6_ADDR, MAC_ADDR
+from ..core import test, check_ip_checksum, check_ipv6_checksum
+
+
+@test
+def test_ipv4_udp_dns_a():
+    sports = [13274] # [53, 13274, 12198, 888, 0]
+    dports = [80] # [53, 5353, 80, 161, 24732]
+    payload = DNS()
+    for sport in sports:
+        for dport in dports:
+            for domain in ['example.com', 'www.example.com', 'masscan.ned']:
+                qd = DNSQR(qname=domain, qtype="A", qclass="IN")
+                req = (
+                    Ether(dst=MAC_ADDR)
+                    / IP(dst=IPV4_ADDR)
+                    / UDP(sport=sport, dport=dport)
+                    / DNS(id=1234, rd=False, opcode=0, qd=qd))
+                resp = srp1(req, timeout=1)
+                assert resp is not None, "expecting answer, got nothing"
+                check_ip_checksum(resp)
+                assert UDP in resp, "no UDP layer found"
+                udp = resp[UDP]
+                assert udp.sport == dport, "unexpected UDP sport: {}".format(udp.sport)
+                assert udp.dport == sport, "unexpected UDP dport: {}".format(udp.dport)
+                if not DNS in udp:
+                    try:
+                        rr = DNS(udp.load)
+                    except Exception:
+                        raise AssertionError("no DNS layer found")
+                else:
+                    rr = udp[DNS]
+                assert(rr.id == 1234), f"unexpected id value: {rr.id}"
+                assert(rr.qr == True), f"unexpected qr value"
+                assert(rr.opcode == 0), f"unexpected opcode value"
+                assert(rr.aa == True), f"unexpected aa value"
+                assert(rr.tc == False), f"unexpected tc value"
+                assert(rr.rd == False), f"unexpected rd value"
+                assert(rr.ra == False), f"unexpected ra value"
+                assert(rr.z == 0), f"unexpected z value"
+                assert(rr.rcode == 0), f"unexpected rcode value"
+                assert(rr.qdcount == 1), f"unexpected qdcount value"
+                assert(rr.ancount == 1), f"unexpected ancount value"
+                assert(rr.nscount == 0), f"unexpected nscount value"
+                assert(rr.arcount == 0), f"unexpected arcount value"
+
+"""
+
+@test
+def test_ipv6_udp_stun():
+    sports = [12345, 55555, 80, 43273]
+    dports = [80, 800, 8000, 3478]
+    payload = bytes.fromhex("000100002112a442000000000000000000000000")
+    for sport in sports:
+        for dport in dports:
+            req = (
+                Ether(dst=MAC_ADDR)
+                / IPv6(dst=IPV6_ADDR)
+                / UDP(sport=sport, dport=dport)
+                / Raw(payload)
+            )
+            resp = srp1(req, timeout=1)
+            assert resp is not None, "expecting answer, got nothing"
+            check_ipv6_checksum(resp)
+            assert UDP in resp
+            udp = resp[UDP]
+            assert udp.sport == dport
+            assert udp.dport == sport
+            resp_payload = udp.payload.load
+            type_, length, magic = struct.unpack(">HHI", resp_payload[:8])
+            tid = resp_payload[8:20]
+            data = resp_payload[20:]
+            assert type_ == 0x0101, "expected type 0X0101, got 0x{:04x}".format(type_)
+            assert length == 24, "expected length 24, got {}".format(length)
+            assert (
+                magic == 0x2112A442
+            ), "expected magic 0x2112a442, got 0x{:08x}".format(magic)
+            assert (
+                tid == b"\x00" * 12
+            ), "expected tid 0x000000000000000000000000, got {:x}".format(tid)
+            expected_data = (
+                bytes.fromhex("000100140002")
+                + struct.pack(">H", sport)
+                + inet_pton(AF_INET6, "2001:41d0::1234:5678")
+            )
+            assert data == expected_data, "unexpected data: {}".format(data)
+
+
+@test
+def test_ipv4_udp_stun_change_port():
+    sports = [12345, 55555, 80, 43273]
+    dports = [80, 800, 8000, 3478, 65535]
+    payload = bytes.fromhex("0001000803a3b9464dd8eb75e19481474293845c0003000400000002")
+    for sport in sports:
+        for dport in dports:
+            req = (
+                Ether(dst=MAC_ADDR)
+                / IP(dst=IPV4_ADDR)
+                / UDP(sport=sport, dport=dport)
+                / Raw(payload)
+            )
+            resp = srp1(req, timeout=1)
+            assert resp is not None, "expecting answer, got nothing"
+            check_ip_checksum(resp)
+            assert UDP in resp, "no UDP layer found"
+            udp = resp[UDP]
+            assert (
+                udp.sport == (dport + 1) % 2**16
+            ), "expected answer from UDP/{}, got it from UDP/{}".format(
+                (dport + 1) % 2**16, udp.sport
+            )
+            assert (
+                udp.dport == sport
+            ), "expected answer to UDP/{}, got it to UDP/{}".format(sport, udp.dport)
+            resp_payload = udp.payload.load
+            type_, length = struct.unpack(">HH", resp_payload[:4])
+            tid = resp_payload[4:20]
+            data = resp_payload[20:]
+            assert type_ == 0x0101, "expected type 0X0101, got 0x{:04x}".format(type_)
+            assert length == 12, "expected length 12, got {}".format(length)
+            assert tid == bytes.fromhex("03a3b9464dd8eb75e19481474293845c"), (
+                "expected tid 0x03a3b9464dd8eb75e19481474293845c, got %r" % tid
+            )
+            expected_data = b"\x00\x01\x00\x08\x00\x01" + struct.pack(
+                ">HBBBB", sport, 192, 0, 0, 0
+            )
+            assert (
+                data == expected_data
+            ), f"unexpected data {data!r} != {expected_data!r}"
+
+
+@test
+def test_ipv6_udp_stun_change_port():
+    sports = [12345, 55555, 80, 43273]
+    dports = [80, 800, 8000, 3478, 65535]
+    payload = bytes.fromhex("0001000803a3b9464dd8eb75e19481474293845c0003000400000002")
+    for sport in sports:
+        for dport in dports:
+            req = (
+                Ether(dst=MAC_ADDR)
+                / IPv6(dst=IPV6_ADDR)
+                / UDP(sport=sport, dport=dport)
+                / Raw(payload)
+            )
+            resp = srp1(req, timeout=1)
+            assert resp is not None, "expecting answer, got nothing"
+            check_ipv6_checksum(resp)
+            assert UDP in resp, "expecting UDP layer in answer, got nothing"
+            udp = resp[UDP]
+            assert (
+                udp.sport == (dport + 1) % 2**16
+            ), "expected answer from UDP/{}, got it from UDP/{}".format(
+                (dport + 1) % 2**16, udp.sport
+            )
+            assert (
+                udp.dport == sport
+            ), "expected answer to UDP/{}, got it to UDP/{}".format(sport, udp.dport)
+            resp_payload = udp.payload.load
+            type_, length = struct.unpack(">HH", resp_payload[:4])
+            tid = resp_payload[4:20]
+            data = resp_payload[20:]
+            assert type_ == 0x0101, "expected type 0X0101, got 0x{:04x}".format(type_)
+            assert length == 24, "expected length 12, got {}".format(length)
+            assert tid == bytes.fromhex("03a3b9464dd8eb75e19481474293845c"), (
+                "expected tid 0x03a3b9464dd8eb75e19481474293845c, got %r" % tid
+            )
+            expected_data = (
+                bytes.fromhex("000100140002")
+                + struct.pack(">H", sport)
+                + inet_pton(AF_INET6, "2001:41d0::1234:5678")
+            )
+            assert (
+                data == expected_data
+            ), f"unexpected data {data!r} != {expected_data!r}"
+"""

--- a/test/src/tests/dns.py
+++ b/test/src/tests/dns.py
@@ -37,14 +37,15 @@ def test_ipv4_udp_dns_in_a():
     payload = DNS()
     for sport in sports:
         for dport in dports:
-            for domain in ['example.com', 'www.example.com', 'masscan.ned']:
+            for domain in ["example.com", "www.example.com", "masscan.ned"]:
                 qd = DNSQR(qname=domain, qtype="A", qclass="IN")
                 dns_req = DNS(id=1234, rd=False, opcode=0, qd=qd)
                 req = (
                     Ether(dst=MAC_ADDR)
                     / IP(dst=IPV4_ADDR)
                     / UDP(sport=sport, dport=dport)
-                    / dns_req)
+                    / dns_req
+                )
                 resp = srp1(req, timeout=1)
                 assert resp is not None, "expecting answer, got nothing"
                 check_ip_checksum(resp)
@@ -59,25 +60,36 @@ def test_ipv4_udp_dns_in_a():
                         raise AssertionError("no DNS layer found")
                 else:
                     dns_rep = udp[DNS]
-                assert(dns_rep.id == 1234), f"unexpected id value: {rr.id}"
-                assert(dns_rep.qr == True), f"unexpected qr value"
-                assert(dns_rep.opcode == 0), f"unexpected opcode value"
-                assert(dns_rep.aa == True), f"unexpected aa value"
-                assert(dns_rep.tc == False), f"unexpected tc value"
-                assert(dns_rep.rd == False), f"unexpected rd value"
-                assert(dns_rep.ra == False), f"unexpected ra value"
-                assert(dns_rep.z == 0), f"unexpected z value"
-                assert(dns_rep.rcode == 0), f"unexpected rcode value"
-                assert(dns_rep.qdcount == 1), f"unexpected qdcount value"
-                assert(dns_rep.ancount == 1), f"unexpected ancount value"
-                assert(dns_rep.nscount == 0), f"unexpected nscount value"
-                assert(dns_rep.arcount == 0), f"unexpected arcount value"
-                assert(raw(dns_rep.qd[0]) == raw(dns_req.qd[0])), f"query in request and response do not match"
-                assert(raw(dns_rep.qd[0].qname) == raw(dns_req.qd[0].qname + b'.')), f"if this test fails, it may mean that scapy fixed the bug in dns.py L134 - if that is so, remove \" + b'.'\" in the test"
-                assert(dns_rep.an[0].rrname == dns_req.qd[0].qname + b'.'), f"if this test fails, it may mean that scapy fixed the bug in dns.py L134 - if that is so, remove \" + b'.'\" in the test"
-                assert(dns_rep.an[0].rclass == dns_req.qd[0].qclass), f"class in answer does not match query"
-                assert(dns_rep.an[0].type == dns_req.qd[0].qtype), f"type in answer does not match query"
-                assert(dns_rep.an[0].rdata == IPV4_ADDR)
+                assert dns_rep.id == 1234, f"unexpected id value: {rr.id}"
+                assert dns_rep.qr == True, f"unexpected qr value"
+                assert dns_rep.opcode == 0, f"unexpected opcode value"
+                assert dns_rep.aa == True, f"unexpected aa value"
+                assert dns_rep.tc == False, f"unexpected tc value"
+                assert dns_rep.rd == False, f"unexpected rd value"
+                assert dns_rep.ra == False, f"unexpected ra value"
+                assert dns_rep.z == 0, f"unexpected z value"
+                assert dns_rep.rcode == 0, f"unexpected rcode value"
+                assert dns_rep.qdcount == 1, f"unexpected qdcount value"
+                assert dns_rep.ancount == 1, f"unexpected ancount value"
+                assert dns_rep.nscount == 0, f"unexpected nscount value"
+                assert dns_rep.arcount == 0, f"unexpected arcount value"
+                assert raw(dns_rep.qd[0]) == raw(
+                    dns_req.qd[0]
+                ), f"query in request and response do not match"
+                assert raw(dns_rep.qd[0].qname) == raw(
+                    dns_req.qd[0].qname + b"."
+                ), f"if this test fails, it may mean that scapy fixed the bug in dns.py L134 - if that is so, remove \" + b'.'\" in the test"
+                assert (
+                    dns_rep.an[0].rrname == dns_req.qd[0].qname + b"."
+                ), f"if this test fails, it may mean that scapy fixed the bug in dns.py L134 - if that is so, remove \" + b'.'\" in the test"
+                assert (
+                    dns_rep.an[0].rclass == dns_req.qd[0].qclass
+                ), f"class in answer does not match query"
+                assert (
+                    dns_rep.an[0].type == dns_req.qd[0].qtype
+                ), f"type in answer does not match query"
+                assert dns_rep.an[0].rdata == IPV4_ADDR
+
 
 @test
 def test_ipv4_udp_dns_in_a_multiple_queries():
@@ -86,13 +98,18 @@ def test_ipv4_udp_dns_in_a_multiple_queries():
     payload = DNS()
     for sport in sports:
         for dport in dports:
-            qd = DNSQR(qname="www.example1.com", qtype="A", qclass="IN")/DNSQR(qname="www.example2.com", qtype="A", qclass="IN")/DNSQR(qname="www.example3.com", qtype="A", qclass="IN")
+            qd = (
+                DNSQR(qname="www.example1.com", qtype="A", qclass="IN")
+                / DNSQR(qname="www.example2.com", qtype="A", qclass="IN")
+                / DNSQR(qname="www.example3.com", qtype="A", qclass="IN")
+            )
             dns_req = DNS(id=1234, rd=False, opcode=0, qd=qd)
             req = (
                 Ether(dst=MAC_ADDR)
                 / IP(dst=IPV4_ADDR)
                 / UDP(sport=sport, dport=dport)
-                / dns_req)
+                / dns_req
+            )
             resp = srp1(req, timeout=1)
             assert resp is not None, "expecting answer, got nothing"
             check_ip_checksum(resp)
@@ -107,23 +124,33 @@ def test_ipv4_udp_dns_in_a_multiple_queries():
                     raise AssertionError("no DNS layer found")
             else:
                 dns_rep = udp[DNS]
-            assert(dns_rep.id == 1234), f"unexpected id value: {rr.id}"
-            assert(dns_rep.qr == True), f"unexpected qr value"
-            assert(dns_rep.opcode == 0), f"unexpected opcode value"
-            assert(dns_rep.aa == True), f"unexpected aa value"
-            assert(dns_rep.tc == False), f"unexpected tc value"
-            assert(dns_rep.rd == False), f"unexpected rd value"
-            assert(dns_rep.ra == False), f"unexpected ra value"
-            assert(dns_rep.z == 0), f"unexpected z value"
-            assert(dns_rep.rcode == 0), f"unexpected rcode value"
-            assert(dns_rep.qdcount == 3), f"unexpected qdcount value"
-            assert(dns_rep.ancount == 3), f"unexpected ancount value"
-            assert(dns_rep.nscount == 0), f"unexpected nscount value"
-            assert(dns_rep.arcount == 0), f"unexpected arcount value"
+            assert dns_rep.id == 1234, f"unexpected id value: {rr.id}"
+            assert dns_rep.qr == True, f"unexpected qr value"
+            assert dns_rep.opcode == 0, f"unexpected opcode value"
+            assert dns_rep.aa == True, f"unexpected aa value"
+            assert dns_rep.tc == False, f"unexpected tc value"
+            assert dns_rep.rd == False, f"unexpected rd value"
+            assert dns_rep.ra == False, f"unexpected ra value"
+            assert dns_rep.z == 0, f"unexpected z value"
+            assert dns_rep.rcode == 0, f"unexpected rcode value"
+            assert dns_rep.qdcount == 3, f"unexpected qdcount value"
+            assert dns_rep.ancount == 3, f"unexpected ancount value"
+            assert dns_rep.nscount == 0, f"unexpected nscount value"
+            assert dns_rep.arcount == 0, f"unexpected arcount value"
             for i, q in enumerate(qd):
-                assert(raw(dns_rep.qd[i]) == raw(dns_req.qd[i])), f"query in request and response do not match"
-                assert(raw(dns_rep.qd[i].qname) == raw(dns_req.qd[i].qname + b'.')), f"if this test fails, it may mean that scapy fixed the bug in dns.py L134 - if that is so, remove \" + b'.'\" in the test"
-                assert(dns_rep.an[i].rrname == dns_req.qd[i].qname + b'.'), f"if this test fails, it may mean that scapy fixed the bug in dns.py L134 - if that is so, remove \" + b'.'\" in the test"
-                assert(dns_rep.an[i].rclass == dns_req.qd[i].qclass), f"class in answer does not match query"
-                assert(dns_rep.an[i].type == dns_req.qd[i].qtype), f"type in answer does not match query"
-                assert(dns_rep.an[i].rdata == IPV4_ADDR)
+                assert raw(dns_rep.qd[i]) == raw(
+                    dns_req.qd[i]
+                ), f"query in request and response do not match"
+                assert raw(dns_rep.qd[i].qname) == raw(
+                    dns_req.qd[i].qname + b"."
+                ), f"if this test fails, it may mean that scapy fixed the bug in dns.py L134 - if that is so, remove \" + b'.'\" in the test"
+                assert (
+                    dns_rep.an[i].rrname == dns_req.qd[i].qname + b"."
+                ), f"if this test fails, it may mean that scapy fixed the bug in dns.py L134 - if that is so, remove \" + b'.'\" in the test"
+                assert (
+                    dns_rep.an[i].rclass == dns_req.qd[i].qclass
+                ), f"class in answer does not match query"
+                assert (
+                    dns_rep.an[i].type == dns_req.qd[i].qtype
+                ), f"type in answer does not match query"
+                assert dns_rep.an[i].rdata == IPV4_ADDR

--- a/test/src/tests/dns.py
+++ b/test/src/tests/dns.py
@@ -14,27 +14,20 @@
 # You should have received a copy of the GNU General Public License
 # along with Masscanned. If not, see <http://www.gnu.org/licenses/>.
 
-from socket import AF_INET6
-import struct
-
 from scapy.compat import raw
 from scapy.layers.dns import DNS, DNSQR
 from scapy.layers.inet import IP, UDP
-from scapy.layers.inet6 import IPv6
 from scapy.layers.l2 import Ether
-from scapy.packet import Raw
-from scapy.pton_ntop import inet_pton
 from scapy.sendrecv import srp1
 
-from ..conf import IPV4_ADDR, IPV6_ADDR, MAC_ADDR
-from ..core import test, check_ip_checksum, check_ipv6_checksum
+from ..conf import IPV4_ADDR, MAC_ADDR
+from ..core import test, check_ip_checksum
 
 
 @test
 def test_ipv4_udp_dns_in_a():
     sports = [53, 13274, 0]
     dports = [53, 5353, 80, 161, 24732]
-    payload = DNS()
     for sport in sports:
         for dport in dports:
             for domain in ["example.com", "www.example.com", "masscan.ned"]:
@@ -53,41 +46,41 @@ def test_ipv4_udp_dns_in_a():
                 udp = resp[UDP]
                 assert udp.sport == dport, "unexpected UDP sport: {}".format(udp.sport)
                 assert udp.dport == sport, "unexpected UDP dport: {}".format(udp.dport)
-                if not DNS in udp:
+                if DNS not in udp:
                     try:
                         dns_rep = DNS(udp.load)
                     except Exception:
                         raise AssertionError("no DNS layer found")
                 else:
                     dns_rep = udp[DNS]
-                assert dns_rep.id == 1234, f"unexpected id value: {rr.id}"
-                assert dns_rep.qr == True, f"unexpected qr value"
-                assert dns_rep.opcode == 0, f"unexpected opcode value"
-                assert dns_rep.aa == True, f"unexpected aa value"
-                assert dns_rep.tc == False, f"unexpected tc value"
-                assert dns_rep.rd == False, f"unexpected rd value"
-                assert dns_rep.ra == False, f"unexpected ra value"
-                assert dns_rep.z == 0, f"unexpected z value"
-                assert dns_rep.rcode == 0, f"unexpected rcode value"
-                assert dns_rep.qdcount == 1, f"unexpected qdcount value"
-                assert dns_rep.ancount == 1, f"unexpected ancount value"
-                assert dns_rep.nscount == 0, f"unexpected nscount value"
-                assert dns_rep.arcount == 0, f"unexpected arcount value"
+                assert dns_rep.id == 1234, f"unexpected id value: {dns_rep.id}"
+                assert dns_rep.qr, "unexpected qr value"
+                assert dns_rep.opcode == 0, "unexpected opcode value"
+                assert dns_rep.aa, "unexpected aa value"
+                assert not dns_rep.tc, "unexpected tc value"
+                assert not dns_rep.rd, "unexpected rd value"
+                assert not dns_rep.ra, "unexpected ra value"
+                assert dns_rep.z == 0, "unexpected z value"
+                assert dns_rep.rcode == 0, "unexpected rcode value"
+                assert dns_rep.qdcount == 1, "unexpected qdcount value"
+                assert dns_rep.ancount == 1, "unexpected ancount value"
+                assert dns_rep.nscount == 0, "unexpected nscount value"
+                assert dns_rep.arcount == 0, "unexpected arcount value"
                 assert raw(dns_rep.qd[0]) == raw(
                     dns_req.qd[0]
-                ), f"query in request and response do not match"
+                ), "query in request and response do not match"
                 assert raw(dns_rep.qd[0].qname) == raw(
                     dns_req.qd[0].qname + b"."
-                ), f"if this test fails, it may mean that scapy fixed the bug in dns.py L134 - if that is so, remove \" + b'.'\" in the test"
+                ), "if this test fails, it may mean that scapy fixed the bug in dns.py L134 - if that is so, remove \" + b'.'\" in the test"
                 assert (
                     dns_rep.an[0].rrname == dns_req.qd[0].qname + b"."
-                ), f"if this test fails, it may mean that scapy fixed the bug in dns.py L134 - if that is so, remove \" + b'.'\" in the test"
+                ), "if this test fails, it may mean that scapy fixed the bug in dns.py L134 - if that is so, remove \" + b'.'\" in the test"
                 assert (
                     dns_rep.an[0].rclass == dns_req.qd[0].qclass
-                ), f"class in answer does not match query"
+                ), "class in answer does not match query"
                 assert (
                     dns_rep.an[0].type == dns_req.qd[0].qtype
-                ), f"type in answer does not match query"
+                ), "type in answer does not match query"
                 assert dns_rep.an[0].rdata == IPV4_ADDR
 
 
@@ -95,7 +88,6 @@ def test_ipv4_udp_dns_in_a():
 def test_ipv4_udp_dns_in_a_multiple_queries():
     sports = [53, 13274, 12198, 888, 0]
     dports = [53, 5353, 80, 161, 24732]
-    payload = DNS()
     for sport in sports:
         for dport in dports:
             qd = (
@@ -117,40 +109,40 @@ def test_ipv4_udp_dns_in_a_multiple_queries():
             udp = resp[UDP]
             assert udp.sport == dport, "unexpected UDP sport: {}".format(udp.sport)
             assert udp.dport == sport, "unexpected UDP dport: {}".format(udp.dport)
-            if not DNS in udp:
+            if DNS not in udp:
                 try:
                     dns_rep = DNS(udp.load)
                 except Exception:
                     raise AssertionError("no DNS layer found")
             else:
                 dns_rep = udp[DNS]
-            assert dns_rep.id == 1234, f"unexpected id value: {rr.id}"
-            assert dns_rep.qr == True, f"unexpected qr value"
-            assert dns_rep.opcode == 0, f"unexpected opcode value"
-            assert dns_rep.aa == True, f"unexpected aa value"
-            assert dns_rep.tc == False, f"unexpected tc value"
-            assert dns_rep.rd == False, f"unexpected rd value"
-            assert dns_rep.ra == False, f"unexpected ra value"
-            assert dns_rep.z == 0, f"unexpected z value"
-            assert dns_rep.rcode == 0, f"unexpected rcode value"
-            assert dns_rep.qdcount == 3, f"unexpected qdcount value"
-            assert dns_rep.ancount == 3, f"unexpected ancount value"
-            assert dns_rep.nscount == 0, f"unexpected nscount value"
-            assert dns_rep.arcount == 0, f"unexpected arcount value"
+            assert dns_rep.id == 1234, f"unexpected id value: {dns_rep.id}"
+            assert dns_rep.qr, "unexpected qr value"
+            assert dns_rep.opcode == 0, "unexpected opcode value"
+            assert dns_rep.aa, "unexpected aa value"
+            assert not dns_rep.tc, "unexpected tc value"
+            assert not dns_rep.rd, "unexpected rd value"
+            assert not dns_rep.ra, "unexpected ra value"
+            assert dns_rep.z == 0, "unexpected z value"
+            assert dns_rep.rcode == 0, "unexpected rcode value"
+            assert dns_rep.qdcount == 3, "unexpected qdcount value"
+            assert dns_rep.ancount == 3, "unexpected ancount value"
+            assert dns_rep.nscount == 0, "unexpected nscount value"
+            assert dns_rep.arcount == 0, "unexpected arcount value"
             for i, q in enumerate(qd):
                 assert raw(dns_rep.qd[i]) == raw(
                     dns_req.qd[i]
-                ), f"query in request and response do not match"
+                ), "query in request and response do not match"
                 assert raw(dns_rep.qd[i].qname) == raw(
                     dns_req.qd[i].qname + b"."
-                ), f"if this test fails, it may mean that scapy fixed the bug in dns.py L134 - if that is so, remove \" + b'.'\" in the test"
+                ), "if this test fails, it may mean that scapy fixed the bug in dns.py L134 - if that is so, remove \" + b'.'\" in the test"
                 assert (
                     dns_rep.an[i].rrname == dns_req.qd[i].qname + b"."
-                ), f"if this test fails, it may mean that scapy fixed the bug in dns.py L134 - if that is so, remove \" + b'.'\" in the test"
+                ), "if this test fails, it may mean that scapy fixed the bug in dns.py L134 - if that is so, remove \" + b'.'\" in the test"
                 assert (
                     dns_rep.an[i].rclass == dns_req.qd[i].qclass
-                ), f"class in answer does not match query"
+                ), "class in answer does not match query"
                 assert (
                     dns_rep.an[i].type == dns_req.qd[i].qtype
-                ), f"type in answer does not match query"
+                ), "type in answer does not match query"
                 assert dns_rep.an[i].rdata == IPV4_ADDR


### PR DESCRIPTION
This PR adds support of DNS in `masscanned`.

![2022-08-04-152155_1919x1055_scrot](https://user-images.githubusercontent.com/3105926/182857467-77819d91-490f-4aa0-9b7c-a707c1b6a1fd.png)

Points of attention:

* so far, only IN/A queries are answered ; other queries are dropped ;
* multiple queries in a single DNS packet are supported ;
* for IN/A queries, the answer always contains the destination IP of the received packet (*i.e.*, the `masscanned` IP address to which the query was issued to) ;
* DNS packets cannot be matched with a regex, so the idea is to try to build a DNS packet with a UDP payload (only if no protocol matched before) -- if it does not fail, then the DNS packet is answered:
```
        /* proto over else (e.g., UDP) */
        let mut i = 0;
        let mut state = BASE_STATE;
        id = PROTO_SMACK.search_next(&mut state, data, &mut i);
        /* because we are not over TCP, we can afford to assume end of pattern */
        if id == NO_MATCH {
            id = PROTO_SMACK.search_next_end(&mut state);
        }
        /* still no match: let us try to parse packet with protocoles
         * that are not matched with a regex */
        if id == NO_MATCH {
            /* try to parse data as a DNS packet */
            if let Ok(dns) = DNSPacket::try_from(data.to_vec()) {
                if let Some(r) = dns.repl(&masscanned, &client_info, None) {
                    return Some(r);
                }
            }
        }
```