### PR TITLE
Option to avoid responding to chosen IP addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ OPTIONS:
     -i, --iface <iface>                           the interface to use for receiving/sending packets
         --ip-addr <iplist>                        Inline list of IP addresses to impersonate, comma-separated
         --ip-addr-file <ipfile>                   File with the list of IP addresses to impersonate
-        --ip-addr <iplist>                        Inline list of IP addresses to impersonate, comma-separated
+        --ignored-ip-addr <iplist>                Inline list of IP addresses to NOT respond to, comma-separated
         --ignored-ip-addr-file <ignoredipfile>    File with the list of IP addresses to NOT respond to
     -m, --mac-addr <mac>                          MAC address to use in the response packets
     -q, --quiet                                   Quiet mode: does not output anything on stdout

--- a/README.md
+++ b/README.md
@@ -86,24 +86,33 @@ A documentation on how to deploy an instance of **masscanned** on a VPS is comin
 ### Supported options
 
 ```
-Network responder - answer them all 0.2.0
 Network answering machine for various network protocols (L2-L3-L4 + applications)
 
-USAGE:
-    masscanned [OPTIONS] --iface <iface>
+Usage: masscanned [OPTIONS] --iface <iface>
 
-OPTIONS:
-    -h, --help                                    Print help information
-    -i, --iface <iface>                           the interface to use for receiving/sending packets
-        --ip-addr <iplist>                        Inline list of IP addresses to impersonate, comma-separated
-        --ip-addr-file <ipfile>                   File with the list of IP addresses to impersonate
-        --ignored-ip-addr <iplist>                Inline list of IP addresses to NOT respond to, comma-separated
-        --ignored-ip-addr-file <ignoredipfile>    File with the list of IP addresses to NOT respond to
-    -m, --mac-addr <mac>                          MAC address to use in the response packets
-    -q, --quiet                                   Quiet mode: does not output anything on stdout
-    --format <format>                             Format in which to output logs [default: console] [others: logfmt]
-    -v                                            Increase message verbosity
-    -V, --version                                 Print version information
+Options:
+  -i, --iface <iface>
+          the interface to use for receiving/sending packets
+  -m, --mac-addr <mac>
+          MAC address to use in the response packets
+      --self-ip-file <selfipfile>
+          File with the list of IP addresses handled by masscanned
+      --self-ip-list <selfiplist>
+          Inline list of IP addresses handled by masscanned, comma-separated
+      --remote-ip-deny-file <remoteipdenyfile>
+          File with the list of IP addresses from which masscanned will ignore packets
+      --remote-ip-deny-list <remoteipdenylist>
+          Inline list of IP addresses from which masscanned will ignore packets
+  -v...
+          Increase message verbosity
+  -q, --quiet
+          Quiet mode: do not output anything on stdout
+      --format <format>
+          Format in which to output logs [default: console] [possible values: console, logfmt]
+  -h, --help
+          Print help information
+  -V, --version
+          Print version information
 ```
 
 ## Supported protocols - details

--- a/README.md
+++ b/README.md
@@ -93,14 +93,17 @@ USAGE:
     masscanned [OPTIONS] --iface <iface>
 
 OPTIONS:
-    -h, --help                     Print help information
-    -i, --iface <iface>            the interface to use for receiving/sending packets
-        --ip-addr <iplist>         Inline list of IP addresses to impersonate, comma-separated
-        --ip-addr-file <ipfile>    File with the list of IP addresses to impersonate
-    -m, --mac-addr <mac>           MAC address to use in the response packets
-    -q, --quiet                    Quiet mode: does not output anything on stdout
-    -v                             Increase message verbosity
-    -V, --version                  Print version information
+    -h, --help                                    Print help information
+    -i, --iface <iface>                           the interface to use for receiving/sending packets
+        --ip-addr <iplist>                        Inline list of IP addresses to impersonate, comma-separated
+        --ip-addr-file <ipfile>                   File with the list of IP addresses to impersonate
+        --ip-addr <iplist>                        Inline list of IP addresses to impersonate, comma-separated
+        --ignored-ip-addr-file <ignoredipfile>    File with the list of IP addresses to NOT respond to
+    -m, --mac-addr <mac>                          MAC address to use in the response packets
+    -q, --quiet                                   Quiet mode: does not output anything on stdout
+    --format <format>                             Format in which to output logs [default: console] [others: logfmt]
+    -v                                            Increase message verbosity
+    -V, --version                                 Print version information
 ```
 
 ## Supported protocols - details

--- a/src/layer_2/arp.rs
+++ b/src/layer_2/arp.rs
@@ -38,7 +38,7 @@ pub fn repl<'a, 'b>(
             masscanned.log.arp_recv(arp_req);
             let ip = IpAddr::V4(arp_req.get_target_proto_addr());
             /* Ignore ARP requests for IP addresses not handled by masscanned */
-            if let Some(ip_addr_list) = masscanned.ip_addresses {
+            if let Some(ip_addr_list) = masscanned.self_ip_list {
                 if !ip_addr_list.contains(&ip) {
                     masscanned.log.arp_drop(arp_req);
                     return None;
@@ -83,8 +83,8 @@ mod tests {
             synack_key: [0, 0],
             mac: MacAddr::from_str("00:11:22:33:44:55").expect("error parsing MAC address"),
             iface: None,
-            ip_addresses: Some(&ips),
-            ignored_ip_addresses: None,
+            self_ip_list: Some(&ips),
+            remote_ip_deny_list: None,
             log: MetaLogger::new(),
         };
         let mut arp_req =

--- a/src/layer_2/arp.rs
+++ b/src/layer_2/arp.rs
@@ -84,6 +84,7 @@ mod tests {
             mac: MacAddr::from_str("00:11:22:33:44:55").expect("error parsing MAC address"),
             iface: None,
             ip_addresses: Some(&ips),
+            ignored_ip_addresses: None,
             log: MetaLogger::new(),
         };
         let mut arp_req =

--- a/src/layer_2/mod.rs
+++ b/src/layer_2/mod.rs
@@ -226,6 +226,7 @@ mod tests {
             mac: mac,
             iface: None,
             ip_addresses: Some(&ips),
+            ignored_ip_addresses: None,
             log: MetaLogger::new(),
         };
         for proto in [EtherTypes::Ipv4, EtherTypes::Ipv6, EtherTypes::Arp] {
@@ -264,6 +265,7 @@ mod tests {
             mac: MacAddr::from_str("00:11:22:33:44:55").expect("error parsing MAC address"),
             iface: None,
             ip_addresses: Some(&ips),
+            ignored_ip_addresses: None,
             log: MetaLogger::new(),
         };
         let mut eth_req = MutableEthernetPacket::owned(vec![

--- a/src/layer_2/mod.rs
+++ b/src/layer_2/mod.rs
@@ -113,7 +113,7 @@ pub fn reply<'a, 'b>(
      * is authorized to answer to (avoid answering to packets addressed to
      * other machines)
      **/
-    if !get_authorized_eth_addr(&masscanned.mac, masscanned.ip_addresses)
+    if !get_authorized_eth_addr(&masscanned.mac, masscanned.self_ip_list)
         .contains(&eth_req.get_destination())
     {
         masscanned.log.eth_drop(eth_req, &client_info);
@@ -225,8 +225,8 @@ mod tests {
             synack_key: [0, 0],
             mac: mac,
             iface: None,
-            ip_addresses: Some(&ips),
-            ignored_ip_addresses: None,
+            self_ip_list: Some(&ips),
+            remote_ip_deny_list: None,
             log: MetaLogger::new(),
         };
         for proto in [EtherTypes::Ipv4, EtherTypes::Ipv6, EtherTypes::Arp] {
@@ -264,8 +264,8 @@ mod tests {
             synack_key: [0, 0],
             mac: MacAddr::from_str("00:11:22:33:44:55").expect("error parsing MAC address"),
             iface: None,
-            ip_addresses: Some(&ips),
-            ignored_ip_addresses: None,
+            self_ip_list: Some(&ips),
+            remote_ip_deny_list: None,
             log: MetaLogger::new(),
         };
         let mut eth_req = MutableEthernetPacket::owned(vec![

--- a/src/layer_3/ipv4.rs
+++ b/src/layer_3/ipv4.rs
@@ -47,18 +47,18 @@ pub fn repl<'a, 'b>(
      * check that the dest. IP address of the packet is one of
      * those handled by masscanned - otherwise, drop the packet.
      **/
-    if let Some(ip_addr_list) = masscanned.ip_addresses {
+    if let Some(ip_addr_list) = masscanned.self_ip_list {
         if !ip_addr_list.contains(&IpAddr::V4(ip_req.get_destination())) {
             masscanned.log.ipv4_drop(&ip_req, &client_info);
             return None;
         }
     }
-    /* If masscanned is configured with ignored IP addresses, then
+    /* If masscanned is configured with a remote ip deny list, then
      * check if the src. IP address of the packet is one of
      * those ignored by masscanned - if so, drop the packet.
      **/
-    if let Some(ignored_ip_addr_list) = masscanned.ignored_ip_addresses {
-        if ignored_ip_addr_list.contains(&IpAddr::V4(ip_req.get_source())) {
+    if let Some(remote_ip_deny_list) = masscanned.remote_ip_deny_list {
+        if remote_ip_deny_list.contains(&IpAddr::V4(ip_req.get_source())) {
             masscanned.log.ipv4_drop(&ip_req, &client_info);
             return None;
         }
@@ -202,8 +202,8 @@ mod tests {
             synack_key: [0, 0],
             mac: MacAddr::from_str("00:11:22:33:44:55").expect("error parsing MAC address"),
             iface: None,
-            ip_addresses: Some(&ips),
-            ignored_ip_addresses: None,
+            self_ip_list: Some(&ips),
+            remote_ip_deny_list: None,
             log: MetaLogger::new(),
         };
         for proto in [
@@ -253,8 +253,8 @@ mod tests {
             synack_key: [0, 0],
             mac: MacAddr::from_str("00:11:22:33:44:55").expect("error parsing MAC address"),
             iface: None,
-            ip_addresses: Some(&ips),
-            ignored_ip_addresses: Some(&blacklist_ips),
+            self_ip_list: Some(&ips),
+            remote_ip_deny_list: Some(&blacklist_ips),
             log: MetaLogger::new(),
         };
         let mut ip_req =

--- a/src/layer_3/ipv4.rs
+++ b/src/layer_3/ipv4.rs
@@ -53,6 +53,16 @@ pub fn repl<'a, 'b>(
             return None;
         }
     }
+    /* If masscanned is configured with ignored IP addresses, then
+     * check if the src. IP address of the packet is one of
+     * those ignored by masscanned - if so, drop the packet.
+     **/
+    if let Some(ignored_ip_addr_list) = masscanned.ignored_ip_addresses {
+        if ignored_ip_addr_list.contains(&IpAddr::V4(ip_req.get_source())) {
+            masscanned.log.ipv4_drop(&ip_req, &client_info);
+            return None;
+        }
+    }
     /* Fill client info with transport layer procotol */
     client_info.transport = Some(ip_req.get_next_level_protocol());
     let mut ip_repl;
@@ -193,6 +203,7 @@ mod tests {
             mac: MacAddr::from_str("00:11:22:33:44:55").expect("error parsing MAC address"),
             iface: None,
             ip_addresses: Some(&ips),
+            ignored_ip_addresses: None,
             log: MetaLogger::new(),
         };
         for proto in [
@@ -240,6 +251,7 @@ mod tests {
             mac: MacAddr::from_str("00:11:22:33:44:55").expect("error parsing MAC address"),
             iface: None,
             ip_addresses: Some(&ips),
+            ignored_ip_addresses: None,
             log: MetaLogger::new(),
         };
         let mut ip_req =

--- a/src/layer_3/ipv6.rs
+++ b/src/layer_3/ipv6.rs
@@ -45,7 +45,7 @@ pub fn repl<'a, 'b>(
      * check that the dest. IP address of the packet is one of
      * those handled by masscanned - otherwise, drop the packet.
      **/
-    if let Some(ip_addr_list) = masscanned.ip_addresses {
+    if let Some(ip_addr_list) = masscanned.self_ip_list {
         if !ip_addr_list.contains(&IpAddr::V6(dst))
             && ip_req.get_next_header() != IpNextHeaderProtocols::Icmpv6
         {
@@ -53,12 +53,12 @@ pub fn repl<'a, 'b>(
             return None;
         }
     }
-    /* If masscanned is configured with ignored IP addresses, then
+    /* If masscanned is configured with a remote ip deny list, then
      * check if the src. IP address of the packet is one of
      * those ignored by masscanned - if so, drop the packet.
      **/
-    if let Some(ignored_ip_addr_list) = masscanned.ignored_ip_addresses {
-        if ignored_ip_addr_list.contains(&IpAddr::V6(src)) {
+    if let Some(remote_ip_deny_list) = masscanned.remote_ip_deny_list {
+        if remote_ip_deny_list.contains(&IpAddr::V6(src)) {
             masscanned.log.ipv6_drop(ip_req, client_info);
             return None;
         }
@@ -215,8 +215,8 @@ mod tests {
             synack_key: [0, 0],
             mac: MacAddr::from_str("00:11:22:33:44:55").expect("error parsing MAC address"),
             iface: None,
-            ip_addresses: Some(&ips),
-            ignored_ip_addresses: None,
+            self_ip_list: Some(&ips),
+            remote_ip_deny_list: None,
             log: MetaLogger::new(),
         };
         for proto in [
@@ -270,8 +270,8 @@ mod tests {
             synack_key: [0, 0],
             mac: MacAddr::from_str("00:11:22:33:44:55").expect("error parsing MAC address"),
             iface: None,
-            ip_addresses: Some(&ips),
-            ignored_ip_addresses: Some(&blacklist_ips),
+            self_ip_list: Some(&ips),
+            remote_ip_deny_list: Some(&blacklist_ips),
             log: MetaLogger::new(),
         };
         let mut ip_req =

--- a/src/layer_3/ipv6.rs
+++ b/src/layer_3/ipv6.rs
@@ -258,15 +258,20 @@ mod tests {
         let masscanned_ip_addr = Ipv6Addr::new(
             0x0000, 0x1111, 0x2222, 0x3333, 0x4444, 0x5555, 0x6666, 0x7777,
         );
+        let blacklist_ip_addr = Ipv6Addr::new(
+            0x1111, 0x1111, 0x1111, 0x1111, 0x1111, 0x1111, 0x1111, 0x1111,
+        );
         let mut ips = HashSet::new();
         ips.insert(IpAddr::V6(masscanned_ip_addr));
+        let mut blacklist_ips = HashSet::new();
+        blacklist_ips.insert(IpAddr::V6(blacklist_ip_addr));
         /* Construct masscanned context object */
         let masscanned = Masscanned {
             synack_key: [0, 0],
             mac: MacAddr::from_str("00:11:22:33:44:55").expect("error parsing MAC address"),
             iface: None,
             ip_addresses: Some(&ips),
-            ignored_ip_addresses: None,
+            ignored_ip_addresses: Some(&blacklist_ips),
             log: MetaLogger::new(),
         };
         let mut ip_req =
@@ -293,6 +298,10 @@ mod tests {
         ip_req.set_destination(Ipv6Addr::new(
             0x0000, 0x1111, 0x2222, 0x3333, 0x4444, 0x5555, 0x6666, 0x7778,
         ));
+        assert!(repl(&ip_req.to_immutable(), &masscanned, &mut client_info) == None);
+        /* Send from a non-legitimate IP address */
+        ip_req.set_source(blacklist_ip_addr);
+        ip_req.set_destination(masscanned_ip_addr);
         assert!(repl(&ip_req.to_immutable(), &masscanned, &mut client_info) == None);
     }
 }

--- a/src/layer_4/icmpv4.rs
+++ b/src/layer_4/icmpv4.rs
@@ -81,6 +81,7 @@ mod tests {
             mac: MacAddr::from_str("00:11:22:33:44:55").expect("error parsing MAC address"),
             iface: None,
             ip_addresses: None,
+            ignored_ip_addresses: None,
             log: MetaLogger::new(),
         };
         let mut icmp_req =

--- a/src/layer_4/icmpv4.rs
+++ b/src/layer_4/icmpv4.rs
@@ -80,8 +80,8 @@ mod tests {
             synack_key: [0, 0],
             mac: MacAddr::from_str("00:11:22:33:44:55").expect("error parsing MAC address"),
             iface: None,
-            ip_addresses: None,
-            ignored_ip_addresses: None,
+            self_ip_list: None,
+            remote_ip_deny_list: None,
             log: MetaLogger::new(),
         };
         let mut icmp_req =

--- a/src/layer_4/icmpv6.rs
+++ b/src/layer_4/icmpv6.rs
@@ -40,7 +40,7 @@ pub fn nd_ns_repl<'a, 'b>(
      * check that the dest. IP address of the packet is one of
      * those handled by masscanned - otherwise, drop the packet.
      **/
-    if let Some(addresses) = masscanned.ip_addresses {
+    if let Some(addresses) = masscanned.self_ip_list {
         if !addresses.contains(&IpAddr::V6(nd_ns_req.get_target_addr())) {
             return None;
         }
@@ -172,8 +172,8 @@ mod tests {
             synack_key: [0, 0],
             mac: MacAddr::from_str("00:11:22:33:44:55").expect("error parsing MAC address"),
             iface: None,
-            ip_addresses: Some(&ips),
-            ignored_ip_addresses: None,
+            self_ip_list: Some(&ips),
+            remote_ip_deny_list: None,
             log: MetaLogger::new(),
         };
         /* Legitimate solicitation */
@@ -246,8 +246,8 @@ mod tests {
             synack_key: [0, 0],
             mac: MacAddr::from_str("00:11:22:33:44:55").expect("error parsing MAC address"),
             iface: None,
-            ip_addresses: Some(&ips),
-            ignored_ip_addresses: None,
+            self_ip_list: Some(&ips),
+            remote_ip_deny_list: None,
             log: MetaLogger::new(),
         };
         let mut icmpv6_echo_req = MutableIcmpv6Packet::owned(vec![

--- a/src/layer_4/icmpv6.rs
+++ b/src/layer_4/icmpv6.rs
@@ -173,6 +173,7 @@ mod tests {
             mac: MacAddr::from_str("00:11:22:33:44:55").expect("error parsing MAC address"),
             iface: None,
             ip_addresses: Some(&ips),
+            ignored_ip_addresses: None,
             log: MetaLogger::new(),
         };
         /* Legitimate solicitation */
@@ -246,6 +247,7 @@ mod tests {
             mac: MacAddr::from_str("00:11:22:33:44:55").expect("error parsing MAC address"),
             iface: None,
             ip_addresses: Some(&ips),
+            ignored_ip_addresses: None,
             log: MetaLogger::new(),
         };
         let mut icmpv6_echo_req = MutableIcmpv6Packet::owned(vec![

--- a/src/layer_4/tcp.rs
+++ b/src/layer_4/tcp.rs
@@ -145,8 +145,8 @@ mod tests {
     fn test_tcp_fin_ack() {
         let masscanned = Masscanned {
             mac: MacAddr(0, 0, 0, 0, 0, 0),
-            ip_addresses: None,
-            ignored_ip_addresses: None,
+            self_ip_list: None,
+            remote_ip_deny_list: None,
             synack_key: [0x06a0a1d63f305e9b, 0xd4d4bcbb7304875f],
             iface: None,
             log: MetaLogger::new(),
@@ -197,8 +197,8 @@ mod tests {
     fn test_tcp_fin_ack_wrap() {
         let masscanned = Masscanned {
             mac: MacAddr(0, 0, 0, 0, 0, 0),
-            ip_addresses: None,
-            ignored_ip_addresses: None,
+            self_ip_list: None,
+            remote_ip_deny_list: None,
             synack_key: [0x06a0a1d63f305e9b, 0xd4d4bcbb7304875f],
             iface: None,
             log: MetaLogger::new(),
@@ -249,8 +249,8 @@ mod tests {
     fn test_synack_cookie_ipv4() {
         let masscanned = Masscanned {
             mac: MacAddr(0, 0, 0, 0, 0, 0),
-            ip_addresses: None,
-            ignored_ip_addresses: None,
+            self_ip_list: None,
+            remote_ip_deny_list: None,
             synack_key: [0x06a0a1d63f305e9b, 0xd4d4bcbb7304875f],
             iface: None,
             log: MetaLogger::new(),
@@ -300,8 +300,8 @@ mod tests {
     fn test_synack_cookie_ipv6() {
         let masscanned = Masscanned {
             mac: MacAddr(0, 0, 0, 0, 0, 0),
-            ip_addresses: None,
-            ignored_ip_addresses: None,
+            self_ip_list: None,
+            remote_ip_deny_list: None,
             synack_key: [0x06a0a1d63f305e9b, 0xd4d4bcbb7304875f],
             iface: None,
             log: MetaLogger::new(),

--- a/src/layer_4/tcp.rs
+++ b/src/layer_4/tcp.rs
@@ -146,6 +146,7 @@ mod tests {
         let masscanned = Masscanned {
             mac: MacAddr(0, 0, 0, 0, 0, 0),
             ip_addresses: None,
+            ignored_ip_addresses: None,
             synack_key: [0x06a0a1d63f305e9b, 0xd4d4bcbb7304875f],
             iface: None,
             log: MetaLogger::new(),
@@ -197,6 +198,7 @@ mod tests {
         let masscanned = Masscanned {
             mac: MacAddr(0, 0, 0, 0, 0, 0),
             ip_addresses: None,
+            ignored_ip_addresses: None,
             synack_key: [0x06a0a1d63f305e9b, 0xd4d4bcbb7304875f],
             iface: None,
             log: MetaLogger::new(),
@@ -248,6 +250,7 @@ mod tests {
         let masscanned = Masscanned {
             mac: MacAddr(0, 0, 0, 0, 0, 0),
             ip_addresses: None,
+            ignored_ip_addresses: None,
             synack_key: [0x06a0a1d63f305e9b, 0xd4d4bcbb7304875f],
             iface: None,
             log: MetaLogger::new(),
@@ -298,6 +301,7 @@ mod tests {
         let masscanned = Masscanned {
             mac: MacAddr(0, 0, 0, 0, 0, 0),
             ip_addresses: None,
+            ignored_ip_addresses: None,
             synack_key: [0x06a0a1d63f305e9b, 0xd4d4bcbb7304875f],
             iface: None,
             log: MetaLogger::new(),

--- a/src/proto/dns/header.rs
+++ b/src/proto/dns/header.rs
@@ -293,6 +293,7 @@ mod tests {
             mac: MacAddr::from_str("00:00:00:00:00:00").expect("error parsing default MAC address"),
             iface: None,
             ip_addresses: None,
+            ignored_ip_addresses: None,
             log: MetaLogger::new(),
         };
         let client_info = ClientInfo::new();
@@ -316,6 +317,7 @@ mod tests {
             mac: MacAddr::from_str("00:00:00:00:00:00").expect("error parsing default MAC address"),
             iface: None,
             ip_addresses: None,
+            ignored_ip_addresses: None,
             log: MetaLogger::new(),
         };
         let client_info = ClientInfo::new();
@@ -340,6 +342,7 @@ mod tests {
             mac: MacAddr::from_str("00:00:00:00:00:00").expect("error parsing default MAC address"),
             iface: None,
             ip_addresses: None,
+            ignored_ip_addresses: None,
             log: MetaLogger::new(),
         };
         let client_info = ClientInfo::new();
@@ -364,6 +367,7 @@ mod tests {
             mac: MacAddr::from_str("00:00:00:00:00:00").expect("error parsing default MAC address"),
             iface: None,
             ip_addresses: None,
+            ignored_ip_addresses: None,
             log: MetaLogger::new(),
         };
         let client_info = ClientInfo::new();

--- a/src/proto/dns/header.rs
+++ b/src/proto/dns/header.rs
@@ -292,8 +292,8 @@ mod tests {
             synack_key: [0, 0],
             mac: MacAddr::from_str("00:00:00:00:00:00").expect("error parsing default MAC address"),
             iface: None,
-            ip_addresses: None,
-            ignored_ip_addresses: None,
+            self_ip_list: None,
+            remote_ip_deny_list: None,
             log: MetaLogger::new(),
         };
         let client_info = ClientInfo::new();
@@ -316,8 +316,8 @@ mod tests {
             synack_key: [0, 0],
             mac: MacAddr::from_str("00:00:00:00:00:00").expect("error parsing default MAC address"),
             iface: None,
-            ip_addresses: None,
-            ignored_ip_addresses: None,
+            self_ip_list: None,
+            remote_ip_deny_list: None,
             log: MetaLogger::new(),
         };
         let client_info = ClientInfo::new();
@@ -341,8 +341,8 @@ mod tests {
             synack_key: [0, 0],
             mac: MacAddr::from_str("00:00:00:00:00:00").expect("error parsing default MAC address"),
             iface: None,
-            ip_addresses: None,
-            ignored_ip_addresses: None,
+            self_ip_list: None,
+            remote_ip_deny_list: None,
             log: MetaLogger::new(),
         };
         let client_info = ClientInfo::new();
@@ -366,8 +366,8 @@ mod tests {
             synack_key: [0, 0],
             mac: MacAddr::from_str("00:00:00:00:00:00").expect("error parsing default MAC address"),
             iface: None,
-            ip_addresses: None,
-            ignored_ip_addresses: None,
+            self_ip_list: None,
+            remote_ip_deny_list: None,
             log: MetaLogger::new(),
         };
         let client_info = ClientInfo::new();

--- a/src/proto/dns/mod.rs
+++ b/src/proto/dns/mod.rs
@@ -628,8 +628,8 @@ mod tests {
             synack_key: [0, 0],
             mac: MacAddr::from_str("00:00:00:00:00:00").expect("error parsing default MAC address"),
             iface: None,
-            ip_addresses: None,
-            ignored_ip_addresses: None,
+            self_ip_list: None,
+            remote_ip_deny_list: None,
             log: MetaLogger::new(),
         };
         let mut client_info = ClientInfo::new();

--- a/src/proto/dns/mod.rs
+++ b/src/proto/dns/mod.rs
@@ -629,6 +629,7 @@ mod tests {
             mac: MacAddr::from_str("00:00:00:00:00:00").expect("error parsing default MAC address"),
             iface: None,
             ip_addresses: None,
+            ignored_ip_addresses: None,
             log: MetaLogger::new(),
         };
         let mut client_info = ClientInfo::new();

--- a/src/proto/dns/query.rs
+++ b/src/proto/dns/query.rs
@@ -238,8 +238,8 @@ mod tests {
             synack_key: [0, 0],
             mac: MacAddr::from_str("00:00:00:00:00:00").expect("error parsing default MAC address"),
             iface: None,
-            ip_addresses: None,
-            ignored_ip_addresses: None,
+            self_ip_list: None,
+            remote_ip_deny_list: None,
             log: MetaLogger::new(),
         };
         let ip_src = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
@@ -306,8 +306,8 @@ mod tests {
             synack_key: [0, 0],
             mac: MacAddr::from_str("00:00:00:00:00:00").expect("error parsing default MAC address"),
             iface: None,
-            ip_addresses: None,
-            ignored_ip_addresses: None,
+            self_ip_list: None,
+            remote_ip_deny_list: None,
             log: MetaLogger::new(),
         };
         let client_info = ClientInfo::new();

--- a/src/proto/dns/query.rs
+++ b/src/proto/dns/query.rs
@@ -239,6 +239,7 @@ mod tests {
             mac: MacAddr::from_str("00:00:00:00:00:00").expect("error parsing default MAC address"),
             iface: None,
             ip_addresses: None,
+            ignored_ip_addresses: None,
             log: MetaLogger::new(),
         };
         let ip_src = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
@@ -306,6 +307,7 @@ mod tests {
             mac: MacAddr::from_str("00:00:00:00:00:00").expect("error parsing default MAC address"),
             iface: None,
             ip_addresses: None,
+            ignored_ip_addresses: None,
             log: MetaLogger::new(),
         };
         let client_info = ClientInfo::new();

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -215,8 +215,8 @@ mod tests {
             synack_key: [0, 0],
             mac: MacAddr::from_str("00:11:22:33:44:55").expect("error parsing MAC address"),
             iface: None,
-            ip_addresses: Some(&ips),
-            ignored_ip_addresses: None,
+            self_ip_list: Some(&ips),
+            remote_ip_deny_list: None,
             log: MetaLogger::new(),
         };
         /***** TEST STUN - MAGIC *****/
@@ -276,8 +276,8 @@ mod tests {
             synack_key: [0, 0],
             mac: MacAddr::from_str("00:11:22:33:44:55").expect("error parsing MAC address"),
             iface: None,
-            ip_addresses: Some(&ips),
-            ignored_ip_addresses: None,
+            self_ip_list: Some(&ips),
+            remote_ip_deny_list: None,
             log: MetaLogger::new(),
         };
         /***** TEST SSH *****/
@@ -318,8 +318,8 @@ mod tests {
             synack_key: [0, 0],
             mac: MacAddr::from_str("00:11:22:33:44:55").expect("error parsing MAC address"),
             iface: None,
-            ip_addresses: Some(&ips),
-            ignored_ip_addresses: None,
+            self_ip_list: Some(&ips),
+            remote_ip_deny_list: None,
             log: MetaLogger::new(),
         };
         /***** TEST GHOST *****/
@@ -352,8 +352,8 @@ mod tests {
             synack_key: [0, 0],
             mac: MacAddr::from_str("00:11:22:33:44:55").expect("error parsing MAC address"),
             iface: None,
-            ip_addresses: Some(&ips),
-            ignored_ip_addresses: None,
+            self_ip_list: Some(&ips),
+            remote_ip_deny_list: None,
             log: MetaLogger::new(),
         };
         /***** TEST COMPLETE REQUEST *****/
@@ -374,8 +374,8 @@ mod tests {
             synack_key: [0, 0],
             mac: MacAddr::from_str("00:11:22:33:44:55").expect("error parsing MAC address"),
             iface: None,
-            ip_addresses: None,
-            ignored_ip_addresses: None,
+            self_ip_list: None,
+            remote_ip_deny_list: None,
             log: MetaLogger::new(),
         };
         let mut client_info = ClientInfo::new();

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -216,6 +216,7 @@ mod tests {
             mac: MacAddr::from_str("00:11:22:33:44:55").expect("error parsing MAC address"),
             iface: None,
             ip_addresses: Some(&ips),
+            ignored_ip_addresses: None,
             log: MetaLogger::new(),
         };
         /***** TEST STUN - MAGIC *****/
@@ -276,6 +277,7 @@ mod tests {
             mac: MacAddr::from_str("00:11:22:33:44:55").expect("error parsing MAC address"),
             iface: None,
             ip_addresses: Some(&ips),
+            ignored_ip_addresses: None,
             log: MetaLogger::new(),
         };
         /***** TEST SSH *****/
@@ -317,6 +319,7 @@ mod tests {
             mac: MacAddr::from_str("00:11:22:33:44:55").expect("error parsing MAC address"),
             iface: None,
             ip_addresses: Some(&ips),
+            ignored_ip_addresses: None,
             log: MetaLogger::new(),
         };
         /***** TEST GHOST *****/
@@ -350,6 +353,7 @@ mod tests {
             mac: MacAddr::from_str("00:11:22:33:44:55").expect("error parsing MAC address"),
             iface: None,
             ip_addresses: Some(&ips),
+            ignored_ip_addresses: None,
             log: MetaLogger::new(),
         };
         /***** TEST COMPLETE REQUEST *****/
@@ -371,6 +375,7 @@ mod tests {
             mac: MacAddr::from_str("00:11:22:33:44:55").expect("error parsing MAC address"),
             iface: None,
             ip_addresses: None,
+            ignored_ip_addresses: None,
             log: MetaLogger::new(),
         };
         let mut client_info = ClientInfo::new();

--- a/src/proto/smb.rs
+++ b/src/proto/smb.rs
@@ -1199,8 +1199,8 @@ mod tests {
             synack_key: [0, 0],
             mac: MacAddr::from_str("00:00:00:00:00:00").expect("error parsing default MAC address"),
             iface: None,
-            ip_addresses: None,
-            ignored_ip_addresses: None,
+            self_ip_list: None,
+            remote_ip_deny_list: None,
             log: MetaLogger::new(),
         };
         let client_info = ClientInfo::new();
@@ -1268,8 +1268,8 @@ mod tests {
             synack_key: [0, 0],
             mac: MacAddr::from_str("00:00:00:00:00:00").expect("error parsing default MAC address"),
             iface: None,
-            ip_addresses: None,
-            ignored_ip_addresses: None,
+            self_ip_list: None,
+            remote_ip_deny_list: None,
             log: MetaLogger::new(),
         };
         let client_info = ClientInfo::new();
@@ -1332,8 +1332,8 @@ mod tests {
             synack_key: [0, 0],
             mac: MacAddr::from_str("00:00:00:00:00:00").expect("error parsing default MAC address"),
             iface: None,
-            ip_addresses: None,
-            ignored_ip_addresses: None,
+            self_ip_list: None,
+            remote_ip_deny_list: None,
             log: MetaLogger::new(),
         };
         let client_info = ClientInfo::new();
@@ -1394,8 +1394,8 @@ mod tests {
             synack_key: [0, 0],
             mac: MacAddr::from_str("00:00:00:00:00:00").expect("error parsing default MAC address"),
             iface: None,
-            ip_addresses: None,
-            ignored_ip_addresses: None,
+            self_ip_list: None,
+            remote_ip_deny_list: None,
             log: MetaLogger::new(),
         };
         let client_info = ClientInfo::new();

--- a/src/proto/smb.rs
+++ b/src/proto/smb.rs
@@ -1200,6 +1200,7 @@ mod tests {
             mac: MacAddr::from_str("00:00:00:00:00:00").expect("error parsing default MAC address"),
             iface: None,
             ip_addresses: None,
+            ignored_ip_addresses: None,
             log: MetaLogger::new(),
         };
         let client_info = ClientInfo::new();
@@ -1268,6 +1269,7 @@ mod tests {
             mac: MacAddr::from_str("00:00:00:00:00:00").expect("error parsing default MAC address"),
             iface: None,
             ip_addresses: None,
+            ignored_ip_addresses: None,
             log: MetaLogger::new(),
         };
         let client_info = ClientInfo::new();
@@ -1331,6 +1333,7 @@ mod tests {
             mac: MacAddr::from_str("00:00:00:00:00:00").expect("error parsing default MAC address"),
             iface: None,
             ip_addresses: None,
+            ignored_ip_addresses: None,
             log: MetaLogger::new(),
         };
         let client_info = ClientInfo::new();
@@ -1392,6 +1395,7 @@ mod tests {
             mac: MacAddr::from_str("00:00:00:00:00:00").expect("error parsing default MAC address"),
             iface: None,
             ip_addresses: None,
+            ignored_ip_addresses: None,
             log: MetaLogger::new(),
         };
         let client_info = ClientInfo::new();

--- a/src/proto/stun.rs
+++ b/src/proto/stun.rs
@@ -442,8 +442,8 @@ mod tests {
             synack_key: [0, 0],
             mac: MacAddr::from_str("00:11:22:33:44:55").expect("error parsing MAC address"),
             iface: None,
-            ip_addresses: Some(&ips),
-            ignored_ip_addresses: None,
+            self_ip_list: Some(&ips),
+            remote_ip_deny_list: None,
             log: MetaLogger::new(),
         };
         let payload_resp = if let Some(r) = repl(payload, &masscanned, &mut client_info, None) {
@@ -503,8 +503,8 @@ mod tests {
             synack_key: [0, 0],
             mac: MacAddr::from_str("00:11:22:33:44:55").expect("error parsing MAC address"),
             iface: None,
-            ip_addresses: Some(&ips),
-            ignored_ip_addresses: None,
+            self_ip_list: Some(&ips),
+            remote_ip_deny_list: None,
             log: MetaLogger::new(),
         };
         client_info.ip.src = Some(IpAddr::V6(test_ip_addr));
@@ -556,8 +556,8 @@ mod tests {
             synack_key: [0, 0],
             mac: MacAddr::from_str("00:11:22:33:44:55").expect("error parsing MAC address"),
             iface: None,
-            ip_addresses: Some(&ips),
-            ignored_ip_addresses: None,
+            self_ip_list: Some(&ips),
+            remote_ip_deny_list: None,
             log: MetaLogger::new(),
         };
         client_info.ip.src = Some(IpAddr::V4(test_ip_addr));
@@ -607,8 +607,8 @@ mod tests {
             synack_key: [0, 0],
             mac: MacAddr::from_str("00:11:22:33:44:55").expect("error parsing MAC address"),
             iface: None,
-            ip_addresses: Some(&ips),
-            ignored_ip_addresses: None,
+            self_ip_list: Some(&ips),
+            remote_ip_deny_list: None,
             log: MetaLogger::new(),
         };
         client_info.ip.src = Some(IpAddr::V4(test_ip_addr));

--- a/src/proto/stun.rs
+++ b/src/proto/stun.rs
@@ -443,6 +443,7 @@ mod tests {
             mac: MacAddr::from_str("00:11:22:33:44:55").expect("error parsing MAC address"),
             iface: None,
             ip_addresses: Some(&ips),
+            ignored_ip_addresses: None,
             log: MetaLogger::new(),
         };
         let payload_resp = if let Some(r) = repl(payload, &masscanned, &mut client_info, None) {
@@ -503,6 +504,7 @@ mod tests {
             mac: MacAddr::from_str("00:11:22:33:44:55").expect("error parsing MAC address"),
             iface: None,
             ip_addresses: Some(&ips),
+            ignored_ip_addresses: None,
             log: MetaLogger::new(),
         };
         client_info.ip.src = Some(IpAddr::V6(test_ip_addr));
@@ -555,6 +557,7 @@ mod tests {
             mac: MacAddr::from_str("00:11:22:33:44:55").expect("error parsing MAC address"),
             iface: None,
             ip_addresses: Some(&ips),
+            ignored_ip_addresses: None,
             log: MetaLogger::new(),
         };
         client_info.ip.src = Some(IpAddr::V4(test_ip_addr));
@@ -605,6 +608,7 @@ mod tests {
             mac: MacAddr::from_str("00:11:22:33:44:55").expect("error parsing MAC address"),
             iface: None,
             ip_addresses: Some(&ips),
+            ignored_ip_addresses: None,
             log: MetaLogger::new(),
         };
         client_info.ip.src = Some(IpAddr::V4(test_ip_addr));

--- a/src/proto/tcb.rs
+++ b/src/proto/tcb.rs
@@ -111,8 +111,8 @@ mod tests {
             synack_key: [0, 0],
             mac: MacAddr::from_str("00:11:22:33:44:55").expect("error parsing MAC address"),
             iface: None,
-            ip_addresses: Some(&ips),
-            ignored_ip_addresses: None,
+            self_ip_list: Some(&ips),
+            remote_ip_deny_list: None,
             log: MetaLogger::new(),
         };
         let cookie = synackcookie::generate(&client_info, &masscanned.synack_key).unwrap();
@@ -166,8 +166,8 @@ mod tests {
             synack_key: [0, 0],
             mac: MacAddr::from_str("00:11:22:33:44:55").expect("error parsing MAC address"),
             iface: None,
-            ip_addresses: Some(&ips),
-            ignored_ip_addresses: None,
+            self_ip_list: Some(&ips),
+            remote_ip_deny_list: None,
             log: MetaLogger::new(),
         };
         let cookie = synackcookie::generate(&client_info, &masscanned.synack_key).unwrap();
@@ -227,8 +227,8 @@ mod tests {
             synack_key: [0, 0],
             mac: MacAddr::from_str("00:11:22:33:44:55").expect("error parsing MAC address"),
             iface: None,
-            ip_addresses: Some(&ips),
-            ignored_ip_addresses: None,
+            self_ip_list: Some(&ips),
+            remote_ip_deny_list: None,
             log: MetaLogger::new(),
         };
         let cookie = synackcookie::generate(&client_info, &masscanned.synack_key).unwrap();

--- a/src/proto/tcb.rs
+++ b/src/proto/tcb.rs
@@ -112,6 +112,7 @@ mod tests {
             mac: MacAddr::from_str("00:11:22:33:44:55").expect("error parsing MAC address"),
             iface: None,
             ip_addresses: Some(&ips),
+            ignored_ip_addresses: None,
             log: MetaLogger::new(),
         };
         let cookie = synackcookie::generate(&client_info, &masscanned.synack_key).unwrap();
@@ -166,6 +167,7 @@ mod tests {
             mac: MacAddr::from_str("00:11:22:33:44:55").expect("error parsing MAC address"),
             iface: None,
             ip_addresses: Some(&ips),
+            ignored_ip_addresses: None,
             log: MetaLogger::new(),
         };
         let cookie = synackcookie::generate(&client_info, &masscanned.synack_key).unwrap();
@@ -226,6 +228,7 @@ mod tests {
             mac: MacAddr::from_str("00:11:22:33:44:55").expect("error parsing MAC address"),
             iface: None,
             ip_addresses: Some(&ips),
+            ignored_ip_addresses: None,
             log: MetaLogger::new(),
         };
         let cookie = synackcookie::generate(&client_info, &masscanned.synack_key).unwrap();

--- a/test/test_masscanned.py
+++ b/test/test_masscanned.py
@@ -163,7 +163,7 @@ masscanned = subprocess.Popen(
         "-vvvvv",
         "-i",
         f"{IFACE}b",
-        "--ip-addr-file",
+        "--self-ip-file",
         ipfile.name,
         "-m",
         MAC_ADDR,


### PR DESCRIPTION
This PR adds 2 options akin to `ip-addr` and `ip-addr-file` that allow to tell Masscanned to not respond to packets that are from a given IP address.

The packets are dropped at the IP layer, following what was already done for restricting the IP addresses that Masscanned should impersonate. 

I haven't added that dropping logic in ARP (which would be based on the Sender Protocol Address), and didn't defer the decision to ICMPv6 when relevant, as I am unsure if it should. What do you think should be done here? Should such an option drop ARP requests when Sender Protocol Address is ignored? What if SPA is manipulated? Either way the two options fit my personal case and motivation for them.

The comment that was modified in ipv6.rs is so it matches the same one in ipv4.rs, which doesn't have a typo.