### PR TITLE
Fix/macos compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,12 +99,6 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bitflags"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
-
-[[package]]
-name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
@@ -413,9 +407,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 
 [[package]]
 name = "libloading"
@@ -455,7 +449,6 @@ dependencies = [
  "itertools",
  "lazy_static",
  "log",
- "netdevice",
  "pcap",
  "pcap-file",
  "pnet",
@@ -479,16 +472,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
  "adler",
-]
-
-[[package]]
-name = "netdevice"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38e2f7ba898cd2fef0e36f91c9cd2bf3b849a2a31510d5f7e1cf515cbf698198"
-dependencies = [
- "bitflags 0.7.0",
- "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ flate2 = "1.0"
 itertools = "0.11.0"
 lazy_static = "1.4.0"
 log = "0.4.20"
-netdevice = "0.1.1"
 pcap = "1.1.0"
 pcap-file = "2.0.0"
 pnet = { version = "0.33.0", features = ["std"] }

--- a/src/masscanned.rs
+++ b/src/masscanned.rs
@@ -196,7 +196,7 @@ fn main() {
         );
         return;
     };
-    if iface.flags & (netdevice::IFF_UP.bits() as u32) == 0 {
+    if !iface.is_up() {
         error!("specified interface is DOWN");
         return;
     }
@@ -286,7 +286,7 @@ fn main() {
     let (mut tx, mut rx) = get_channel(masscanned.iface.unwrap());
     loop {
         /* check if network interface is still up */
-        if masscanned.iface.unwrap().flags & (netdevice::IFF_UP.bits() as u32) == 0 {
+        if !masscanned.iface.unwrap().is_up() {
             error!("interface is DOWN - aborting");
             break;
         }


### PR DESCRIPTION
Hello there 👋 
I was looking for some good first issues and I've found https://github.com/ivre/masscanned/issues/162.
So, I've tried to compile the project on my mac and I've got the same issue mentioned there.
Then, I tried to compile it using my windows and I bumped into another issue, also related to `netdevice`. 
My first attempt to fix was to remove `netdevice` and use `libc` instead, and it worked just fine on my mac, but not on windows, then checked the `pnet` crate and realized they already have a method to check for up interfaces and use that instead, feels much cleaner overall.

Closes https://github.com/ivre/masscanned/issues/162