### PR TITLE
 Docker: use rust image as builder (latest version) 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 # This file is part of masscanned.
-# Copyright 2021 - The IVRE project
+# Copyright 2021 - 2024 The IVRE project
 #
 # Masscanned is free software: you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by
@@ -101,3 +101,20 @@ jobs:
     - name: Display logs
       run: echo STDOUT; cat test/res/masscanned.stdout && echo && echo STDERR && cat test/res/masscanned.stderr
       if: failure()
+
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Git checkout
+      uses: actions/checkout@v2
+
+    - name: Build archive
+      run: git archive --format=tar --prefix=masscanned-master/ HEAD -o docker/masscanned.tar
+
+    - name: Build image
+      uses: docker/build-push-action@v5
+      with:
+        push: false
+        context: docker/
+        file: docker/Dockerfile-local

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # This file is part of masscanned.
-# Copyright 2021 - 2023 The IVRE project
+# Copyright 2021 - 2024 The IVRE project
 #
 # Masscanned is free software: you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by
@@ -14,16 +14,20 @@
 # You should have received a copy of the GNU General Public License
 # along with Masscanned. If not, see <http://www.gnu.org/licenses/>.
 
-FROM debian:12 AS builder
+FROM debian:12 AS fetcher
 
-ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get -q update && \
+    apt-get -qy --no-install-recommends install ca-certificates curl && \
+    curl -L https://github.com/ivre/masscanned/archive/refs/heads/master.tar.gz | tar zxf -
 
-RUN echo "deb http://deb.debian.org/debian testing main" > /etc/apt/sources.list.d/testing.list && \
-    apt-get -q update && \
-    apt-get -qy --no-install-recommends install cargo ca-certificates curl && \
-    curl -L https://github.com/ivre/masscanned/archive/refs/heads/master.tar.gz | tar zxf - && \
-    cd masscanned-master && \
+
+FROM rust AS builder
+
+COPY --from=fetcher /masscanned-master /masscanned-master
+
+RUN cd masscanned-master && \
     cargo build --release
+
 
 FROM debian:12
 LABEL maintainer="Pierre LALET <pierre@droids-corp.org>"

--- a/docker/Dockerfile-local
+++ b/docker/Dockerfile-local
@@ -1,0 +1,38 @@
+# This file is part of masscanned.
+# Copyright 2021 - 2024 The IVRE project
+#
+# Masscanned is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Masscanned is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Masscanned. If not, see <http://www.gnu.org/licenses/>.
+
+FROM rust AS builder
+
+ADD masscanned.tar ./
+
+RUN cd masscanned-master && \
+    cargo build --release
+
+
+FROM debian:12
+LABEL maintainer="Pierre LALET <pierre@droids-corp.org>"
+
+COPY --from=builder /masscanned-master/target/release/masscanned /usr/local/bin/masscanned
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get -q update && \
+    apt-get -qy --no-install-recommends install iproute2 iptables && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+COPY runmasscanned /usr/local/bin/runmasscanned
+
+CMD /usr/local/bin/runmasscanned


### PR DESCRIPTION
This fixes build since Debian comes with a rust version that is a bit too old to compile masscanned with the fixed dependencies.

Also, this PR introduces a new CI job to make sure the Docker image builds correctly for each PR & push.